### PR TITLE
fix(integrators): use API product document title across integrators section

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": ["-c", "DEV_PORT=5199 pnpm dev"],
+      "port": 5199
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ yarn.lock
 
 # Local Netlify folder
 .netlify
+
+# Claude Code personal settings
+.claude/settings.local.json

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,6 +6,11 @@ export const TwoFACodePrice = {
   sms: 0.015,
 } as const
 
+// Document title for the whole /integrators section. Titles are not translated
+// anywhere in the app (the default comes from the APP_TITLE env var), so this
+// stays a plain constant for consistency.
+export const IntegratorsPageTitle = 'Vocdoni API - Integrate secure digital voting easily'
+
 export const OAuthProviders = ['google'] as const
 export type OAuthProvider = (typeof OAuthProviders)[number]
 

--- a/src/elements/LayoutIntegrators.tsx
+++ b/src/elements/LayoutIntegrators.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { useIntegratorMenuConfig } from '~components/Dashboard/Menu/menus'
+import { IntegratorsPageTitle } from '~constants'
 import DashboardShell from '~elements/DashboardShell'
+import { useDocumentTitle } from '~utils/use-document-title'
 
 // The integrator app reuses the exact same dashboard layout and user menu as admin; only the
 // sidebar nav items differ (see useIntegratorMenuConfig).
 const LayoutIntegrators: React.FC = () => {
+  useDocumentTitle(IntegratorsPageTitle)
   const menu = useIntegratorMenuConfig()
   return <DashboardShell menu={menu} />
 }

--- a/src/elements/LayoutIntegratorsAuth.tsx
+++ b/src/elements/LayoutIntegratorsAuth.tsx
@@ -3,12 +3,15 @@ import { useState } from 'react'
 import { Trans } from 'react-i18next'
 import { LuArrowLeft } from 'react-icons/lu'
 import { Outlet, Link as RouterLink, useLocation } from 'react-router-dom'
+import { IntegratorsPageTitle } from '~constants'
 import { AuthOutletContextType } from '~elements/LayoutAuth'
 import { Routes } from '~routes'
+import { useDocumentTitle } from '~utils/use-document-title'
 
 // Single-column auth layout for the integrators app. Mirrors LayoutAuth's card styling but
 // drops the testimonials column — integrators get a focused, single-column experience.
 const LayoutIntegratorsAuth = () => {
+  useDocumentTitle(IntegratorsPageTitle)
   const [title, setTitle] = useState<string | null>(null)
   const [subtitle, setSubtitle] = useState<string | null>(null)
   const { pathname } = useLocation()

--- a/src/utils/use-document-title.test.ts
+++ b/src/utils/use-document-title.test.ts
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react'
+import { useDocumentTitle } from './use-document-title'
+
+describe('useDocumentTitle', () => {
+  const originalTitle = 'Original title'
+
+  beforeEach(() => {
+    document.title = originalTitle
+  })
+
+  it('sets the document title on mount', () => {
+    renderHook(() => useDocumentTitle('Custom title'))
+
+    expect(document.title).toBe('Custom title')
+  })
+
+  it('updates the document title when the title changes', () => {
+    const { rerender } = renderHook(({ title }) => useDocumentTitle(title), {
+      initialProps: { title: 'First title' },
+    })
+
+    rerender({ title: 'Second title' })
+
+    expect(document.title).toBe('Second title')
+  })
+
+  it('restores the previous document title on unmount', () => {
+    const { unmount } = renderHook(() => useDocumentTitle('Custom title'))
+
+    unmount()
+
+    expect(document.title).toBe(originalTitle)
+  })
+
+  it('restores the original title on unmount even after title changes', () => {
+    const { rerender, unmount } = renderHook(({ title }) => useDocumentTitle(title), {
+      initialProps: { title: 'First title' },
+    })
+
+    rerender({ title: 'Second title' })
+    unmount()
+
+    expect(document.title).toBe(originalTitle)
+  })
+})

--- a/src/utils/use-document-title.ts
+++ b/src/utils/use-document-title.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+/**
+ * Sets the document title while the calling component is mounted, restoring
+ * the previous title on unmount. SSR pages get their titles from Vike
+ * `+title.ts` hooks instead; this is only for client-rendered sections that
+ * need to override the app-wide default.
+ */
+export const useDocumentTitle = (title: string) => {
+  useEffect(() => {
+    const previous = document.title
+    document.title = title
+    return () => {
+      document.title = previous
+    }
+  }, [title])
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,11 @@ const viteconfig = ({ mode }: { mode: string }) => {
     // command and its parser rejects unknown flags like `--host`/`--port`.
     server: {
       host: true,
+      // Same reason as `host`: the port can only be set here, so honor an optional
+      // DEV_PORT env override (e.g. `DEV_PORT=5199 pnpm dev`) for machines where
+      // the default port is already taken by another app.
+      port: process.env.DEV_PORT ? Number(process.env.DEV_PORT) : undefined,
+      strictPort: Boolean(process.env.DEV_PORT),
     },
     build: {
       outDir,


### PR DESCRIPTION
## What

On https://app-stg.vocdoni.io/integrators the browser tab showed the app-wide default title ("Vocdoni - Digital voting SaaS platform"). The integrators section now shows **"Vocdoni API - Integrate secure digital voting easily"** instead — on the dashboard pages and the integrators auth pages (signin/signup/password). The rest of the app is unchanged.

## Why

The whole `/integrators` section is client-rendered behind the Vike SPA catch-all, so it inherits the global default from `src/pages/+title.ts` and there was no client-side per-route title mechanism.

## How

- New `useDocumentTitle` hook (`src/utils/use-document-title.ts`): sets `document.title` while mounted and restores the previous title on unmount, so SPA navigation back to the rest of the app recovers the default. Unit-tested.
- Applied in `LayoutIntegrators` (dashboard) and `LayoutIntegratorsAuth` (signin/signup/password) via a shared `IntegratorsPageTitle` constant. Titles are not translated anywhere in the app (env-derived default, hardcoded SSR `+title.ts` values), so the constant is intentionally untranslated for consistency.
- Dev-tooling enabler used to verify this: the Vite dev server now honors an optional `DEV_PORT` env override (`DEV_PORT=5199 pnpm dev`), since Vike rejects `--port` on the CLI (same reasoning as the existing `host: true` config comment).

## Verification

- `pnpm test`: 518 passed (including 4 new hook tests); `prettier --check` clean on the touched files. Note: `tsc` fails on develop with a pre-existing unrelated error (`ShareButton.tsx` — stale Chakra typegen missing the `breadcrumb` link variant); the touched files introduce no new errors.
- Manually in the dev server: `/ca/integrators` (dashboard) and `/ca/integrators/signin` show the new title; client-side navigation to `/ca/admin` restores "Vocdoni - Digital voting SaaS platform", and navigating back re-applies the integrators title.