### PR TITLE
experiment(theme): warm editorial look + 17-palette live switcher (throwaway)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "vocdoni-app",
+      "runtimeExecutable": "env",
+      "runtimeArgs": ["DEV_PORT=5299", "pnpm", "dev"],
+      "port": 5299,
+      "autoPort": false
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@ethersproject/abstract-signer": "^5.8.0",
     "@ethersproject/providers": "^5.8.0",
     "@ethersproject/wallet": "^5.8.0",
+    "@fontsource-variable/fraunces": "^5.2.9",
+    "@fontsource-variable/hanken-grotesk": "^5.2.8",
     "@fontsource/inter": "^5.2.8",
     "@gsap/react": "^2.1.2",
     "@lexical/code": "^0.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       '@ethersproject/wallet':
         specifier: ^5.8.0
         version: 5.8.0
+      '@fontsource-variable/fraunces':
+        specifier: ^5.2.9
+        version: 5.2.9
+      '@fontsource-variable/hanken-grotesk':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@fontsource/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -1100,6 +1106,12 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fontsource-variable/fraunces@5.2.9':
+    resolution: {integrity: sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==}
+
+  '@fontsource-variable/hanken-grotesk@5.2.8':
+    resolution: {integrity: sha512-K7hu09ZKReBc7EifRLeM4K94NZBrxFEg0nGcISmVwlFQOJo4EmYkLXTWEwr5JcNW4z2hr5zy8vLS2sxC8JDmrQ==}
 
   '@fontsource/inter@5.2.8':
     resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
@@ -8240,6 +8252,10 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fontsource-variable/fraunces@5.2.9': {}
+
+  '@fontsource-variable/hanken-grotesk@5.2.8': {}
 
   '@fontsource/inter@5.2.8': {}
 

--- a/src/components/Dashboard/Contents.tsx
+++ b/src/components/Dashboard/Contents.tsx
@@ -10,6 +10,7 @@ export const DashboardBox = (props: BoxProps) => (
   <Box
     borderRadius='md'
     border='1px solid'
+    bg='card.surface'
     _dark={{ borderColor: 'brand.700' }}
     _light={{ borderColor: 'gray.200' }}
     p={4}

--- a/src/components/Dashboard/Menu/PaletteSwitcher.tsx
+++ b/src/components/Dashboard/Menu/PaletteSwitcher.tsx
@@ -1,0 +1,77 @@
+import { Box, Flex, Text } from '@chakra-ui/react'
+import { useContext, useEffect, useState } from 'react'
+import { DashboardLayoutContext } from '~elements/DashboardLayoutContext'
+import { DEFAULT_PALETTE, palettes } from '~theme/palettes'
+
+const STORAGE_KEY = 'demo-palette'
+
+const applyPalette = (id: string) => {
+  if (id === DEFAULT_PALETTE.id) {
+    delete document.documentElement.dataset.palette
+  } else {
+    document.documentElement.dataset.palette = id
+  }
+}
+
+/**
+ * Throwaway demo control: switches between the experiment palettes defined in
+ * ~theme/palettes so the team can compare color directions live.
+ */
+const PaletteSwitcher = () => {
+  const { reduced } = useContext(DashboardLayoutContext)
+  const [active, setActive] = useState(DEFAULT_PALETTE.id)
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored && palettes.some((p) => p.id === stored)) {
+      setActive(stored)
+      applyPalette(stored)
+    }
+  }, [])
+
+  const select = (id: string) => {
+    setActive(id)
+    localStorage.setItem(STORAGE_KEY, id)
+    applyPalette(id)
+  }
+
+  if (reduced) return null
+
+  return (
+    <Box px={4} py={3} borderTop='1px solid' borderColor='table.border'>
+      <Text fontSize='xs' fontWeight='bold' color='texts.subtle' mb={2}>
+        Theme preview
+      </Text>
+      <Flex gap={2} flexWrap='wrap'>
+        {palettes.map((palette) => (
+          <Box
+            key={palette.id}
+            as='button'
+            title={palette.label}
+            aria-label={palette.label}
+            aria-pressed={active === palette.id}
+            onClick={() => select(palette.id)}
+            w='22px'
+            h='22px'
+            borderRadius='full'
+            cursor='pointer'
+            border='1px solid'
+            borderColor='table.border'
+            outline={active === palette.id ? '2px solid' : 'none'}
+            outlineColor='var(--pal-accent)'
+            outlineOffset='1px'
+            // Split circle: surface tint on top, accent on the bottom
+            background={`linear-gradient(135deg, ${palette.swatch.bg} 50%, ${palette.swatch.accent} 50%)`}
+            transition='transform 0.15s ease'
+            _hover={{ transform: 'scale(1.15)' }}
+          />
+        ))}
+      </Flex>
+      <Text fontSize='xs' color='texts.subtle' mt={2}>
+        {palettes.find((p) => p.id === active)?.label}
+      </Text>
+    </Box>
+  )
+}
+
+export default PaletteSwitcher

--- a/src/components/Dashboard/Menu/UserProfile.tsx
+++ b/src/components/Dashboard/Menu/UserProfile.tsx
@@ -57,7 +57,7 @@ const UserProfile = () => {
           gap={2}
           w='full'
           colorPalette='gray'
-          variant='subtle'
+          variant='ghost'
           justifyContent='start'
           borderRadius='none'
           mt={2}

--- a/src/components/Dashboard/Menu/index.tsx
+++ b/src/components/Dashboard/Menu/index.tsx
@@ -24,6 +24,7 @@ import { Routes } from '~src/router/routes'
 import { DashboardBookerModalButton } from '../Booker'
 import { DashboardMenuConfig } from './menus'
 import { DashboardMenuOptions } from './Options'
+import PaletteSwitcher from './PaletteSwitcher'
 import UserProfile from './UserProfile'
 
 const DashboardMenu = ({
@@ -202,6 +203,7 @@ const DashboardMenuContent = ({
       </Box>
       <Box mt='auto'>
         {menu.tutorial && <SidebarTutorial />}
+        <PaletteSwitcher />
         <UserProfile />
       </Box>
     </>

--- a/src/components/Dashboard/Menu/index.tsx
+++ b/src/components/Dashboard/Menu/index.tsx
@@ -44,9 +44,6 @@ const DashboardMenu = ({
     <>
       {/* Sidebar for large screens */}
       <Box
-        borderRight='1px solid'
-        borderRightColor='table.border'
-        bgColor='dashboard.menu'
         display={{ base: 'none', md: 'flex' }}
         flexDirection='column'
         position='sticky'

--- a/src/elements/DashboardShell.tsx
+++ b/src/elements/DashboardShell.tsx
@@ -32,7 +32,7 @@ const DashboardShell: React.FC<{ menu: DashboardMenuConfig }> = ({ menu }) => {
   return (
     <DashboardLayoutContext.Provider value={{ reduced: reducedValue }}>
       <DashboardLayoutProviders>
-        <Flex minH='100svh' w='full' _dark={{ bg: 'brand.650' }} maxW='max-window-width' margin='0 auto'>
+        <Flex minH='100svh' w='full' bg='dashboard.menu' maxW='max-window-width' margin='0 auto'>
           {/* Sidebar for large screens */}
           <DashboardMenu
             isOpen={isOpen}
@@ -41,7 +41,19 @@ const DashboardShell: React.FC<{ menu: DashboardMenuConfig }> = ({ menu }) => {
             menu={menu}
           />
 
-          <Flex flex='1 1 0' flexDirection='column' minW={0}>
+          {/* Inset content panel: floats on the sidebar background with its own border and radius */}
+          <Flex
+            flex='1 1 0'
+            flexDirection='column'
+            minW={0}
+            m={{ base: 1.5, md: 2 }}
+            ml={{ base: 1.5, md: 0 }}
+            bg='chakra.body.bg'
+            borderRadius='2xl'
+            border='1px solid'
+            borderColor='table.border'
+            boxShadow='var(--box-shadow)'
+          >
             <AnnouncementBanner />
             <Flex alignItems='center' px={4} pt={3} pb={2} display={{ base: 'flex', md: 'none' }} gap={2}>
               <IconButton aria-label={t('menu.open')} colorPalette='gray' variant='subtle' size='xs' onClick={onOpen}>

--- a/src/theme/Theme.tsx
+++ b/src/theme/Theme.tsx
@@ -6,6 +6,8 @@ import { rainbowStyles } from '~theme'
 import { ColorModeProvider, useColorMode } from '~theme/color-mode'
 import { system } from '~theme/system'
 
+import '@fontsource-variable/fraunces/index.css'
+import '@fontsource-variable/hanken-grotesk/index.css'
 import '@fontsource/inter/300.css'
 import '@fontsource/inter/400.css'
 import '@fontsource/inter/500.css'

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -30,4 +30,18 @@ export const colors = {
     light: { value: 'var(--pal-ghost)' },
     dark: { value: 'var(--pal-dark-menu)' },
   },
+
+  // Status ramps (alerts, progress, badges…): palette-tuned via vars so each
+  // demo palette controls how muted or vivid they are
+  ...Object.fromEntries(
+    ['red', 'orange', 'green', 'blue', 'purple'].map((name) => [
+      name,
+      Object.fromEntries(
+        ['50', '100', '200', '300', '400', '500', '600', '700', '800', '900', '950'].map((stop) => [
+          stop,
+          { value: `var(--pal-${name}-${stop})` },
+        ])
+      ),
+    ])
+  ),
 }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,32 +1,33 @@
-// Warm editorial experiment: brand = warm ink ramp, gray = warm cream/ink grays
+// Warm editorial experiment: every value is a palette var (see palettes.ts)
+// so the demo palette switcher can swap them at runtime.
 export const colors = {
   brand: {
     // comments refer to (unused) button styles
-    50: { value: 'oklch(0.962 0.022 97)' }, // ghost hover (light) — tinted cream
-    100: { value: 'oklch(0.936 0.033 97)' }, // hover (light) — deeper cream
-    200: { value: 'oklch(0.988 0.011 97)' }, // outline hover / ghost active (light) — cream
-    300: { value: 'oklch(0.24 0.013 106 / 0.2)' }, // outline active (light)
-    500: { value: 'oklch(0.24 0.013 106)' }, // base solid — warm ink
-    550: { value: 'oklch(0.235 0.012 107)' }, // custom (auth bg) — dark surface
-    600: { value: 'oklch(0.32 0.014 106)' }, // solid hover
-    650: { value: 'oklch(0.22 0.012 106)' }, // custom — dark body bg
-    700: { value: 'oklch(0.29 0.016 106)' }, // solid active
-    800: { value: 'oklch(0.34 0.016 106)' }, // link active (dark)
+    50: { value: 'var(--pal-ghost)' }, // ghost hover (light)
+    100: { value: 'var(--pal-ghost-2)' }, // hover (light)
+    200: { value: 'var(--pal-t50)' }, // outline hover / ghost active (light)
+    300: { value: 'var(--pal-ink20)' }, // outline active (light)
+    500: { value: 'var(--pal-solid)' }, // base solid — ink
+    550: { value: 'var(--pal-dark-2)' }, // custom (auth bg) — dark surface
+    600: { value: 'var(--pal-solid-hover)' }, // solid hover
+    650: { value: 'var(--pal-dark-1)' }, // custom — dark body bg
+    700: { value: 'var(--pal-solid-active)' }, // solid active
+    800: { value: 'var(--pal-dark-3)' }, // link active (dark)
   },
 
   gray: {
-    50: { value: 'oklch(0.988 0.011 97)' },
-    100: { value: 'oklch(0.962 0.022 97)' },
-    200: { value: 'oklch(0.911 0.02 100)' },
-    400: { value: 'oklch(0.72 0.015 100)' },
-    500: { value: 'oklch(0.55 0.015 103)' },
-    600: { value: 'oklch(0.45 0.014 104)' },
-    700: { value: 'oklch(0.35 0.014 105)' },
-    800: { value: 'oklch(0.27 0.013 106)' },
+    50: { value: 'var(--pal-t50)' },
+    100: { value: 'var(--pal-ghost)' },
+    200: { value: 'var(--pal-g200)' },
+    400: { value: 'var(--pal-g400)' },
+    500: { value: 'var(--pal-g500)' },
+    600: { value: 'var(--pal-g600)' },
+    700: { value: 'var(--pal-g700)' },
+    800: { value: 'var(--pal-g800)' },
   },
 
   dashboardMenu: {
-    light: { value: 'oklch(0.962 0.022 97)' },
-    dark: { value: 'oklch(0.25 0.013 106)' },
+    light: { value: 'var(--pal-ghost)' },
+    dark: { value: 'var(--pal-dark-menu)' },
   },
 }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -27,7 +27,7 @@ export const colors = {
   },
 
   dashboardMenu: {
-    light: { value: 'var(--pal-ghost)' },
+    light: { value: 'var(--pal-menu)' },
     dark: { value: 'var(--pal-dark-menu)' },
   },
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,31 +1,32 @@
+// Warm editorial experiment: brand = warm ink ramp, gray = warm cream/ink grays
 export const colors = {
   brand: {
     // comments refer to (unused) button styles
-    50: { value: '#e5e5e5' }, // ghost hover (light)
-    100: { value: '#cccccc' }, // hover (light)
-    200: { value: '#fafafa' }, // outline hover / ghost active (light)
-    300: { value: '#bbbbbb' }, // outline active (light)
-    500: { value: '#000000' }, // base solid
-    550: { value: '#262626' }, // custom (auth bg)
-    600: { value: '#353535' }, // solid hover
-    650: { value: '#0a0a0a' }, // custom
-    700: { value: '#2e2e2e' }, // solid active
-    800: { value: '#3f3f3f' }, // link active (dark)
+    50: { value: 'oklch(0.962 0.022 97)' }, // ghost hover (light) — tinted cream
+    100: { value: 'oklch(0.936 0.033 97)' }, // hover (light) — deeper cream
+    200: { value: 'oklch(0.988 0.011 97)' }, // outline hover / ghost active (light) — cream
+    300: { value: 'oklch(0.24 0.013 106 / 0.2)' }, // outline active (light)
+    500: { value: 'oklch(0.24 0.013 106)' }, // base solid — warm ink
+    550: { value: 'oklch(0.235 0.012 107)' }, // custom (auth bg) — dark surface
+    600: { value: 'oklch(0.32 0.014 106)' }, // solid hover
+    650: { value: 'oklch(0.22 0.012 106)' }, // custom — dark body bg
+    700: { value: 'oklch(0.29 0.016 106)' }, // solid active
+    800: { value: 'oklch(0.34 0.016 106)' }, // link active (dark)
   },
 
   gray: {
-    50: { value: '#fcfcfc' },
-    100: { value: 'whitesmoke' },
-    200: { value: '#e4e4e7' },
-    400: { value: '#b2b2b2' },
-    500: { value: '#737373' },
-    600: { value: '#52525b' },
-    700: { value: '#3f3f46' },
-    800: { value: '#27272a' },
+    50: { value: 'oklch(0.988 0.011 97)' },
+    100: { value: 'oklch(0.962 0.022 97)' },
+    200: { value: 'oklch(0.911 0.02 100)' },
+    400: { value: 'oklch(0.72 0.015 100)' },
+    500: { value: 'oklch(0.55 0.015 103)' },
+    600: { value: 'oklch(0.45 0.014 104)' },
+    700: { value: 'oklch(0.35 0.014 105)' },
+    800: { value: 'oklch(0.27 0.013 106)' },
   },
 
   dashboardMenu: {
-    light: { value: '#fbfbfb' },
-    dark: { value: '#18181b' },
+    light: { value: 'oklch(0.962 0.022 97)' },
+    dark: { value: 'oklch(0.25 0.013 106)' },
   },
 }

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -15,6 +15,11 @@ type PaletteInput = {
   ink: { h: number; c: number }
   /** accent color for links/highlights, light and dark mode variants */
   accent: { light: string; lightHover: string; dark: string; darkHover: string }
+  /**
+   * "Easier on the eyes": warm, lower-glare surfaces (off-white instead of
+   * near-white) and slightly softened text contrast for the light mode.
+   */
+  soft?: boolean
 }
 
 export type Palette = {
@@ -26,17 +31,24 @@ export type Palette = {
   dark: Record<string, string>
 }
 
-const build = ({ id, label, surface: s, ink, accent }: PaletteInput): Palette => {
+const build = ({ id, label, surface: s, ink, accent, soft = false }: PaletteInput): Palette => {
   const inkAt = (l: number, alpha?: number) =>
     alpha ? `oklch(${l} ${ink.c} ${ink.h} / ${alpha})` : `oklch(${l} ${ink.c} ${ink.h})`
   const surfaceAt = (l: number, cMult = 1) => `oklch(${l} ${s.c * cMult} ${s.h})`
   const lightText = (alpha?: number) => (alpha ? `oklch(0.95 0.012 ${s.h} / ${alpha})` : `oklch(0.95 0.012 ${s.h})`)
 
+  // "soft" palettes drop the light surfaces off pure white and ease the text
+  // contrast down a notch, so the whole UI is gentler to look at.
+  const L = soft
+    ? { bg: 0.972, menu: 0.95, auth: 0.925, t50: 0.978, g200: 0.9 }
+    : { bg: 0.988, menu: 0.962, auth: 0.936, t50: 0.988, g200: 0.911 }
+  const tL = soft ? 0.3 : 0.24 // light-mode text lightness
+
   // Constants shared by both modes (raw brand/gray ramps don't mode-switch)
   const constants = {
-    '--pal-t50': surfaceAt(0.988), // brand.200 / gray.50
-    '--pal-ghost': surfaceAt(0.962, 2), // brand.50 / gray.100 / menu tint
-    '--pal-ghost-2': surfaceAt(0.936, 3), // brand.100 / muted panels
+    '--pal-t50': surfaceAt(L.t50), // brand.200 / gray.50
+    '--pal-ghost': surfaceAt(L.menu, 2), // brand.50 / gray.100 / menu tint
+    '--pal-ghost-2': surfaceAt(L.auth, 3), // brand.100 / muted panels
     '--pal-ink20': inkAt(0.24, 0.2),
     '--pal-solid': inkAt(0.24),
     '--pal-solid-hover': inkAt(0.32),
@@ -45,7 +57,7 @@ const build = ({ id, label, surface: s, ink, accent }: PaletteInput): Palette =>
     '--pal-dark-2': `oklch(0.235 0.012 ${ink.h})`, // dark auth bg
     '--pal-dark-menu': `oklch(0.25 0.013 ${ink.h})`, // dark sidebar/menu
     '--pal-dark-3': `oklch(0.34 0.016 ${ink.h})`, // dark muted bg
-    '--pal-g200': surfaceAt(0.911, 2),
+    '--pal-g200': surfaceAt(L.g200, 2),
     '--pal-g400': inkAt(0.72),
     '--pal-g500': inkAt(0.55),
     '--pal-g600': inkAt(0.45),
@@ -56,17 +68,17 @@ const build = ({ id, label, surface: s, ink, accent }: PaletteInput): Palette =>
   return {
     id,
     label,
-    swatch: { bg: surfaceAt(0.962, 2), accent: accent.light },
+    swatch: { bg: surfaceAt(L.menu, 2), accent: accent.light },
     light: {
       ...constants,
-      '--pal-bg': surfaceAt(0.988),
-      '--pal-menu': surfaceAt(0.962, 2),
-      '--pal-auth-bg': surfaceAt(0.936, 3),
-      '--pal-text': inkAt(0.24),
-      '--pal-text-strong': inkAt(0.24),
-      '--pal-text-64': inkAt(0.24, 0.64),
-      '--pal-placeholder': inkAt(0.24, 0.55),
-      '--pal-hairline': inkAt(0.24, 0.1),
+      '--pal-bg': surfaceAt(L.bg),
+      '--pal-menu': surfaceAt(L.menu, 2),
+      '--pal-auth-bg': surfaceAt(L.auth, 3),
+      '--pal-text': inkAt(tL),
+      '--pal-text-strong': inkAt(tL),
+      '--pal-text-64': inkAt(tL, 0.64),
+      '--pal-placeholder': inkAt(tL, 0.55),
+      '--pal-hairline': inkAt(tL, 0.1),
       '--pal-accent': accent.light,
       '--pal-accent-hover': accent.lightHover,
     },
@@ -246,6 +258,59 @@ export const palettes: Palette[] = [
       lightHover: 'oklch(0.42 0.095 45)',
       dark: 'oklch(0.66 0.1 45)',
       darkHover: 'oklch(0.73 0.095 45)',
+    },
+  }),
+  // Softer, lower-glare set — warm off-white surfaces, gentler contrast
+  build({
+    id: 'sepia',
+    label: 'Sepia',
+    soft: true,
+    surface: { h: 75, c: 0.022 },
+    ink: { h: 55, c: 0.02 },
+    accent: {
+      light: 'oklch(0.5 0.08 65)',
+      lightHover: 'oklch(0.44 0.075 65)',
+      dark: 'oklch(0.72 0.08 70)',
+      darkHover: 'oklch(0.78 0.075 70)',
+    },
+  }),
+  build({
+    id: 'linen',
+    label: 'Linen',
+    soft: true,
+    surface: { h: 95, c: 0.018 },
+    ink: { h: 110, c: 0.016 },
+    accent: {
+      light: 'oklch(0.48 0.055 145)',
+      lightHover: 'oklch(0.42 0.05 145)',
+      dark: 'oklch(0.68 0.055 145)',
+      darkHover: 'oklch(0.74 0.05 145)',
+    },
+  }),
+  build({
+    id: 'dusk',
+    label: 'Dusk',
+    soft: true,
+    surface: { h: 250, c: 0.012 },
+    ink: { h: 255, c: 0.018 },
+    accent: {
+      light: 'oklch(0.5 0.06 250)',
+      lightHover: 'oklch(0.44 0.055 250)',
+      dark: 'oklch(0.7 0.06 250)',
+      darkHover: 'oklch(0.76 0.055 250)',
+    },
+  }),
+  build({
+    id: 'fog',
+    label: 'Fog',
+    soft: true,
+    surface: { h: 265, c: 0.01 },
+    ink: { h: 265, c: 0.012 },
+    accent: {
+      light: 'oklch(0.5 0.06 275)',
+      lightHover: 'oklch(0.44 0.055 275)',
+      dark: 'oklch(0.7 0.06 275)',
+      darkHover: 'oklch(0.76 0.055 275)',
     },
   }),
 ]

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -20,6 +20,8 @@ type PaletteInput = {
    * near-white) and slightly softened text contrast for the light mode.
    */
   soft?: boolean
+  /** Exact lightness overrides for pixel-matching a reference design */
+  levels?: Partial<{ bg: number; menu: number; auth: number; t50: number; g200: number; text: number }>
 }
 
 export type Palette = {
@@ -31,7 +33,7 @@ export type Palette = {
   dark: Record<string, string>
 }
 
-const build = ({ id, label, surface: s, ink, accent, soft = false }: PaletteInput): Palette => {
+const build = ({ id, label, surface: s, ink, accent, soft = false, levels }: PaletteInput): Palette => {
   const inkAt = (l: number, alpha?: number) =>
     alpha ? `oklch(${l} ${ink.c} ${ink.h} / ${alpha})` : `oklch(${l} ${ink.c} ${ink.h})`
   const surfaceAt = (l: number, cMult = 1) => `oklch(${l} ${s.c * cMult} ${s.h})`
@@ -39,10 +41,13 @@ const build = ({ id, label, surface: s, ink, accent, soft = false }: PaletteInpu
 
   // "soft" palettes drop the light surfaces off pure white and ease the text
   // contrast down a notch, so the whole UI is gentler to look at.
-  const L = soft
-    ? { bg: 0.972, menu: 0.95, auth: 0.925, t50: 0.978, g200: 0.9 }
-    : { bg: 0.988, menu: 0.962, auth: 0.936, t50: 0.988, g200: 0.911 }
-  const tL = soft ? 0.3 : 0.24 // light-mode text lightness
+  const L = {
+    ...(soft
+      ? { bg: 0.972, menu: 0.95, auth: 0.925, t50: 0.978, g200: 0.9 }
+      : { bg: 0.988, menu: 0.962, auth: 0.936, t50: 0.988, g200: 0.911 }),
+    ...levels,
+  }
+  const tL = levels?.text ?? (soft ? 0.3 : 0.24) // light-mode text lightness
 
   // Constants shared by both modes (raw brand/gray ramps don't mode-switch)
   const constants = {
@@ -227,18 +232,20 @@ export const palettes: Palette[] = [
       darkHover: 'oklch(0.74 0.05 145)',
     },
   }),
-  // Inspired by Littlebird: warm cream paper surface, gentle fresh-green accent
+  // Matched to the reference screenshots: quiet warm ivory (~#F8F6F1 bg,
+  // ~#ECE9E0 tint), soft warm-black text, fresh green kept to small accents
   build({
-    id: 'littlebird',
-    label: 'Littlebird',
+    id: 'smooth',
+    label: 'Smooth',
     soft: true,
-    surface: { h: 85, c: 0.024 },
-    ink: { h: 70, c: 0.018 },
+    surface: { h: 95, c: 0.006 },
+    ink: { h: 95, c: 0.01 },
+    levels: { bg: 0.977, menu: 0.938, auth: 0.92, t50: 0.982, g200: 0.9, text: 0.27 },
     accent: {
-      light: 'oklch(0.5 0.08 150)',
-      lightHover: 'oklch(0.44 0.075 150)',
-      dark: 'oklch(0.7 0.08 150)',
-      darkHover: 'oklch(0.76 0.075 150)',
+      light: 'oklch(0.52 0.1 152)',
+      lightHover: 'oklch(0.46 0.095 152)',
+      dark: 'oklch(0.7 0.09 152)',
+      darkHover: 'oklch(0.76 0.085 152)',
     },
   }),
 ]

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -21,7 +21,17 @@ type PaletteInput = {
    */
   soft?: boolean
   /** Exact lightness overrides for pixel-matching a reference design */
-  levels?: Partial<{ bg: number; menu: number; ghost: number; auth: number; t50: number; g200: number; text: number }>
+  levels?: Partial<{
+    bg: number
+    menu: number
+    ghost: number
+    auth: number
+    t50: number
+    g200: number
+    text: number
+    /** Card surface lightness; defaults to `bg` so cards sit flat on the canvas */
+    card: number
+  }>
   /**
    * Vivid status/accent ramps (saturated alerts, buttons, progress bars).
    * Default is muted, institution-friendly chroma.
@@ -124,6 +134,9 @@ const build = ({
       '--pal-bg': surfaceAt(L.bg),
       '--pal-menu': surfaceAt(L.menu, 2),
       '--pal-auth-bg': surfaceAt(L.auth, 3),
+      // Card surface: equals the canvas by default (flat), lifts to a lighter
+      // surface when a palette sets `levels.card` (e.g. white cards on gray).
+      '--pal-card': surfaceAt(levels?.card ?? L.bg),
       '--pal-text': inkAt(tL),
       '--pal-text-strong': inkAt(tL),
       '--pal-text-64': inkAt(tL, 0.64),
@@ -140,6 +153,8 @@ const build = ({
       '--pal-bg': `oklch(0.22 0.012 ${ink.h})`,
       '--pal-menu': `oklch(0.25 0.013 ${ink.h})`,
       '--pal-auth-bg': `oklch(0.235 0.012 ${ink.h})`,
+      // Dark cards stay flat on the dark canvas (no elevation change)
+      '--pal-card': `oklch(0.22 0.012 ${ink.h})`,
       '--pal-text': lightText(),
       '--pal-text-strong': lightText(0.8),
       '--pal-text-64': lightText(0.66),
@@ -313,7 +328,7 @@ export const palettes: Palette[] = [
     navSolid: false,
     surface: { h: 250, c: 0.003 },
     ink: { h: 250, c: 0.01 },
-    levels: { bg: 0.963, menu: 1, ghost: 0.955, auth: 0.945, t50: 1, g200: 0.915, text: 0.22 },
+    levels: { bg: 0.963, menu: 1, ghost: 0.955, auth: 0.945, t50: 1, g200: 0.915, text: 0.22, card: 1 },
     accent: {
       light: 'oklch(0.61 0.185 260)',
       lightHover: 'oklch(0.55 0.18 260)',

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -129,18 +129,6 @@ export const palettes: Palette[] = [
     },
   }),
   build({
-    id: 'petrol',
-    label: 'Petrol',
-    surface: { h: 215, c: 0.007 },
-    ink: { h: 225, c: 0.016 },
-    accent: {
-      light: 'oklch(0.45 0.085 205)',
-      lightHover: 'oklch(0.38 0.08 205)',
-      dark: 'oklch(0.65 0.08 200)',
-      darkHover: 'oklch(0.72 0.08 200)',
-    },
-  }),
-  build({
     id: 'burgundy',
     label: 'Burgundy',
     surface: { h: 75, c: 0.008 },
@@ -165,18 +153,6 @@ export const palettes: Palette[] = [
     },
   }),
   build({
-    id: 'sage',
-    label: 'Sage',
-    surface: { h: 140, c: 0.006 },
-    ink: { h: 150, c: 0.014 },
-    accent: {
-      light: 'oklch(0.42 0.07 150)',
-      lightHover: 'oklch(0.36 0.065 150)',
-      dark: 'oklch(0.66 0.07 150)',
-      darkHover: 'oklch(0.73 0.07 150)',
-    },
-  }),
-  build({
     id: 'iris',
     label: 'Iris',
     surface: { h: 290, c: 0.005 },
@@ -189,18 +165,6 @@ export const palettes: Palette[] = [
     },
   }),
   build({
-    id: 'slate',
-    label: 'Slate',
-    surface: { h: 240, c: 0.006 },
-    ink: { h: 245, c: 0.014 },
-    accent: {
-      light: 'oklch(0.45 0.07 235)',
-      lightHover: 'oklch(0.38 0.065 235)',
-      dark: 'oklch(0.68 0.07 235)',
-      darkHover: 'oklch(0.75 0.065 235)',
-    },
-  }),
-  build({
     id: 'bronze',
     label: 'Bronze',
     surface: { h: 85, c: 0.01 },
@@ -210,30 +174,6 @@ export const palettes: Palette[] = [
       lightHover: 'oklch(0.43 0.085 75)',
       dark: 'oklch(0.72 0.09 80)',
       darkHover: 'oklch(0.78 0.085 80)',
-    },
-  }),
-  build({
-    id: 'teal',
-    label: 'Teal',
-    surface: { h: 190, c: 0.006 },
-    ink: { h: 200, c: 0.014 },
-    accent: {
-      light: 'oklch(0.46 0.08 185)',
-      lightHover: 'oklch(0.4 0.075 185)',
-      dark: 'oklch(0.66 0.08 185)',
-      darkHover: 'oklch(0.73 0.075 185)',
-    },
-  }),
-  build({
-    id: 'plum',
-    label: 'Plum',
-    surface: { h: 340, c: 0.006 },
-    ink: { h: 345, c: 0.014 },
-    accent: {
-      light: 'oklch(0.42 0.11 350)',
-      lightHover: 'oklch(0.36 0.105 350)',
-      dark: 'oklch(0.66 0.11 350)',
-      darkHover: 'oklch(0.73 0.1 350)',
     },
   }),
   build({
@@ -287,30 +227,18 @@ export const palettes: Palette[] = [
       darkHover: 'oklch(0.74 0.05 145)',
     },
   }),
+  // Inspired by Littlebird: warm cream paper surface, gentle fresh-green accent
   build({
-    id: 'dusk',
-    label: 'Dusk',
+    id: 'littlebird',
+    label: 'Littlebird',
     soft: true,
-    surface: { h: 250, c: 0.012 },
-    ink: { h: 255, c: 0.018 },
+    surface: { h: 85, c: 0.024 },
+    ink: { h: 70, c: 0.018 },
     accent: {
-      light: 'oklch(0.5 0.06 250)',
-      lightHover: 'oklch(0.44 0.055 250)',
-      dark: 'oklch(0.7 0.06 250)',
-      darkHover: 'oklch(0.76 0.055 250)',
-    },
-  }),
-  build({
-    id: 'fog',
-    label: 'Fog',
-    soft: true,
-    surface: { h: 265, c: 0.01 },
-    ink: { h: 265, c: 0.012 },
-    accent: {
-      light: 'oklch(0.5 0.06 275)',
-      lightHover: 'oklch(0.44 0.055 275)',
-      dark: 'oklch(0.7 0.06 275)',
-      darkHover: 'oklch(0.76 0.055 275)',
+      light: 'oklch(0.5 0.08 150)',
+      lightHover: 'oklch(0.44 0.075 150)',
+      dark: 'oklch(0.7 0.08 150)',
+      darkHover: 'oklch(0.76 0.075 150)',
     },
   }),
 ]

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -22,7 +22,32 @@ type PaletteInput = {
   soft?: boolean
   /** Exact lightness overrides for pixel-matching a reference design */
   levels?: Partial<{ bg: number; menu: number; auth: number; t50: number; g200: number; text: number }>
+  /**
+   * Vivid status/accent ramps (saturated alerts, buttons, progress bars).
+   * Default is muted, institution-friendly chroma.
+   */
+  vivid?: boolean
 }
+
+/**
+ * Status ramps consumed by Chakra's default component styling (alerts,
+ * progress bars, badges, buttons via colorPalette). One ramp per Chakra
+ * color name, hue fixed, chroma scaled per palette (muted vs vivid).
+ */
+const STATUS_HUES: Record<string, number> = { red: 27, orange: 55, green: 150, blue: 245, purple: 300 }
+const RAMP_STOPS: Array<[stop: string, l: number, cFactor: number]> = [
+  ['50', 0.97, 0.15],
+  ['100', 0.94, 0.25],
+  ['200', 0.89, 0.4],
+  ['300', 0.82, 0.6],
+  ['400', 0.72, 0.85],
+  ['500', 0.6, 1],
+  ['600', 0.51, 1],
+  ['700', 0.44, 0.9],
+  ['800', 0.38, 0.75],
+  ['900', 0.31, 0.55],
+  ['950', 0.25, 0.4],
+]
 
 export type Palette = {
   id: string
@@ -33,7 +58,7 @@ export type Palette = {
   dark: Record<string, string>
 }
 
-const build = ({ id, label, surface: s, ink, accent, soft = false, levels }: PaletteInput): Palette => {
+const build = ({ id, label, surface: s, ink, accent, soft = false, levels, vivid = false }: PaletteInput): Palette => {
   const inkAt = (l: number, alpha?: number) =>
     alpha ? `oklch(${l} ${ink.c} ${ink.h} / ${alpha})` : `oklch(${l} ${ink.c} ${ink.h})`
   const surfaceAt = (l: number, cMult = 1) => `oklch(${l} ${s.c * cMult} ${s.h})`
@@ -68,6 +93,13 @@ const build = ({ id, label, surface: s, ink, accent, soft = false, levels }: Pal
     '--pal-g600': inkAt(0.45),
     '--pal-g700': inkAt(0.35),
     '--pal-g800': inkAt(0.27),
+    // Status ramps: muted for institutional palettes, saturated when vivid
+    ...Object.fromEntries(
+      Object.entries(STATUS_HUES).flatMap(([name, hue]) => {
+        const maxC = vivid ? 0.19 : 0.11
+        return RAMP_STOPS.map(([stop, l, cFactor]) => [`--pal-${name}-${stop}`, `oklch(${l} ${maxC * cFactor} ${hue})`])
+      })
+    ),
   }
 
   return {
@@ -86,6 +118,9 @@ const build = ({ id, label, surface: s, ink, accent, soft = false, levels }: Pal
       '--pal-hairline': inkAt(tL, 0.1),
       '--pal-accent': accent.light,
       '--pal-accent-hover': accent.lightHover,
+      '--pal-accent-soft': `color-mix(in oklab, ${accent.light} 12%, transparent)`,
+      '--pal-nav-active-bg': vivid ? accent.light : `color-mix(in oklab, ${accent.light} 12%, transparent)`,
+      '--pal-nav-active-fg': vivid ? 'white' : accent.light,
     },
     dark: {
       ...constants,
@@ -99,6 +134,9 @@ const build = ({ id, label, surface: s, ink, accent, soft = false, levels }: Pal
       '--pal-hairline': 'oklch(1 0 0 / 0.1)',
       '--pal-accent': accent.dark,
       '--pal-accent-hover': accent.darkHover,
+      '--pal-accent-soft': `color-mix(in oklab, ${accent.dark} 16%, transparent)`,
+      '--pal-nav-active-bg': vivid ? accent.light : `color-mix(in oklab, ${accent.dark} 16%, transparent)`,
+      '--pal-nav-active-fg': vivid ? 'white' : accent.dark,
     },
   }
 }
@@ -241,6 +279,7 @@ export const palettes: Palette[] = [
   build({
     id: 'azure',
     label: 'Azure',
+    vivid: true,
     surface: { h: 255, c: 0.001 },
     ink: { h: 255, c: 0.006 },
     levels: { bg: 0.997, menu: 0.961, auth: 0.944, t50: 1, g200: 0.92, text: 0.22 },

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -21,12 +21,14 @@ type PaletteInput = {
    */
   soft?: boolean
   /** Exact lightness overrides for pixel-matching a reference design */
-  levels?: Partial<{ bg: number; menu: number; auth: number; t50: number; g200: number; text: number }>
+  levels?: Partial<{ bg: number; menu: number; ghost: number; auth: number; t50: number; g200: number; text: number }>
   /**
    * Vivid status/accent ramps (saturated alerts, buttons, progress bars).
    * Default is muted, institution-friendly chroma.
    */
   vivid?: boolean
+  /** Solid accent pill for the active nav item (defaults to `vivid`) */
+  navSolid?: boolean
 }
 
 /**
@@ -58,10 +60,21 @@ export type Palette = {
   dark: Record<string, string>
 }
 
-const build = ({ id, label, surface: s, ink, accent, soft = false, levels, vivid = false }: PaletteInput): Palette => {
+const build = ({
+  id,
+  label,
+  surface: s,
+  ink,
+  accent,
+  soft = false,
+  levels,
+  vivid = false,
+  navSolid = vivid,
+}: PaletteInput): Palette => {
   const inkAt = (l: number, alpha?: number) =>
     alpha ? `oklch(${l} ${ink.c} ${ink.h} / ${alpha})` : `oklch(${l} ${ink.c} ${ink.h})`
-  const surfaceAt = (l: number, cMult = 1) => `oklch(${l} ${s.c * cMult} ${s.h})`
+  // Chroma clamps to 0 at (near-)white so L=1 surfaces render pure #fff
+  const surfaceAt = (l: number, cMult = 1) => `oklch(${l} ${l >= 0.999 ? 0 : s.c * cMult} ${s.h})`
   const lightText = (alpha?: number) => (alpha ? `oklch(0.95 0.012 ${s.h} / ${alpha})` : `oklch(0.95 0.012 ${s.h})`)
 
   // "soft" palettes drop the light surfaces off pure white and ease the text
@@ -77,7 +90,7 @@ const build = ({ id, label, surface: s, ink, accent, soft = false, levels, vivid
   // Constants shared by both modes (raw brand/gray ramps don't mode-switch)
   const constants = {
     '--pal-t50': surfaceAt(L.t50), // brand.200 / gray.50
-    '--pal-ghost': surfaceAt(L.menu, 2), // brand.50 / gray.100 / menu tint
+    '--pal-ghost': surfaceAt(L.ghost ?? L.menu, 2), // brand.50 / gray.100 / hover fills
     '--pal-ghost-2': surfaceAt(L.auth, 3), // brand.100 / muted panels
     '--pal-ink20': inkAt(0.24, 0.2),
     '--pal-solid': inkAt(0.24),
@@ -119,8 +132,8 @@ const build = ({ id, label, surface: s, ink, accent, soft = false, levels, vivid
       '--pal-accent': accent.light,
       '--pal-accent-hover': accent.lightHover,
       '--pal-accent-soft': `color-mix(in oklab, ${accent.light} 12%, transparent)`,
-      '--pal-nav-active-bg': vivid ? accent.light : `color-mix(in oklab, ${accent.light} 12%, transparent)`,
-      '--pal-nav-active-fg': vivid ? 'white' : accent.light,
+      '--pal-nav-active-bg': navSolid ? accent.light : `color-mix(in oklab, ${accent.light} 12%, transparent)`,
+      '--pal-nav-active-fg': navSolid ? 'white' : accent.light,
     },
     dark: {
       ...constants,
@@ -135,8 +148,8 @@ const build = ({ id, label, surface: s, ink, accent, soft = false, levels, vivid
       '--pal-accent': accent.dark,
       '--pal-accent-hover': accent.darkHover,
       '--pal-accent-soft': `color-mix(in oklab, ${accent.dark} 16%, transparent)`,
-      '--pal-nav-active-bg': vivid ? accent.light : `color-mix(in oklab, ${accent.dark} 16%, transparent)`,
-      '--pal-nav-active-fg': vivid ? 'white' : accent.dark,
+      '--pal-nav-active-bg': navSolid ? accent.light : `color-mix(in oklab, ${accent.dark} 16%, transparent)`,
+      '--pal-nav-active-fg': navSolid ? 'white' : accent.dark,
     },
   }
 }
@@ -288,6 +301,24 @@ export const palettes: Palette[] = [
       lightHover: 'oklch(0.53 0.215 255)',
       dark: 'oklch(0.64 0.19 255)',
       darkHover: 'oklch(0.7 0.18 255)',
+    },
+  }),
+  // Matched to the "Acme Inc" reference screenshot: white sidebar, light
+  // cool-gray content background, white cards, soft blue accent used as a
+  // light wash on the active nav item. Vivid status ramps like the reference.
+  build({
+    id: 'cloud',
+    label: 'Cloud',
+    vivid: true,
+    navSolid: false,
+    surface: { h: 250, c: 0.003 },
+    ink: { h: 250, c: 0.01 },
+    levels: { bg: 0.963, menu: 1, ghost: 0.955, auth: 0.945, t50: 1, g200: 0.915, text: 0.22 },
+    accent: {
+      light: 'oklch(0.61 0.185 260)',
+      lightHover: 'oklch(0.55 0.18 260)',
+      dark: 'oklch(0.68 0.17 258)',
+      darkHover: 'oklch(0.74 0.16 258)',
     },
   }),
 ]

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -235,6 +235,22 @@ export const palettes: Palette[] = [
       darkHover: 'oklch(0.76 0.085 152)',
     },
   }),
+  // Matched to the "Noma" reference screenshot: pure white content panel,
+  // light neutral-gray sidebar (~#F2F2F2), near-black text, vivid iOS-style
+  // blue accent (~#007AFF)
+  build({
+    id: 'azure',
+    label: 'Azure',
+    surface: { h: 255, c: 0.001 },
+    ink: { h: 255, c: 0.006 },
+    levels: { bg: 0.997, menu: 0.961, auth: 0.944, t50: 1, g200: 0.92, text: 0.22 },
+    accent: {
+      light: 'oklch(0.59 0.225 255)',
+      lightHover: 'oklch(0.53 0.215 255)',
+      dark: 'oklch(0.64 0.19 255)',
+      darkHover: 'oklch(0.7 0.18 255)',
+    },
+  }),
 ]
 
 export const DEFAULT_PALETTE = palettes[0]

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -207,19 +207,6 @@ export const palettes: Palette[] = [
   }),
   // Softer, lower-glare set — warm off-white surfaces, gentler contrast
   build({
-    id: 'sepia',
-    label: 'Sepia',
-    soft: true,
-    surface: { h: 75, c: 0.022 },
-    ink: { h: 55, c: 0.02 },
-    accent: {
-      light: 'oklch(0.5 0.08 65)',
-      lightHover: 'oklch(0.44 0.075 65)',
-      dark: 'oklch(0.72 0.08 70)',
-      darkHover: 'oklch(0.78 0.075 70)',
-    },
-  }),
-  build({
     id: 'linen',
     label: 'Linen',
     soft: true,

--- a/src/theme/palettes.ts
+++ b/src/theme/palettes.ts
@@ -1,0 +1,267 @@
+/**
+ * Warm editorial experiment: runtime-switchable demo palettes.
+ *
+ * Every themed color in the token layer is a `var(--pal-*)` reference; each
+ * palette defines those vars for light and dark mode. Switching palettes is
+ * just `document.documentElement.dataset.palette = id` (unset = default).
+ */
+
+type PaletteInput = {
+  id: string
+  label: string
+  /** hue + chroma of the near-white surfaces */
+  surface: { h: number; c: number }
+  /** hue + chroma of the ink (text, solid buttons, dark surfaces) */
+  ink: { h: number; c: number }
+  /** accent color for links/highlights, light and dark mode variants */
+  accent: { light: string; lightHover: string; dark: string; darkHover: string }
+}
+
+export type Palette = {
+  id: string
+  label: string
+  /** swatch colors for the switcher UI */
+  swatch: { bg: string; accent: string }
+  light: Record<string, string>
+  dark: Record<string, string>
+}
+
+const build = ({ id, label, surface: s, ink, accent }: PaletteInput): Palette => {
+  const inkAt = (l: number, alpha?: number) =>
+    alpha ? `oklch(${l} ${ink.c} ${ink.h} / ${alpha})` : `oklch(${l} ${ink.c} ${ink.h})`
+  const surfaceAt = (l: number, cMult = 1) => `oklch(${l} ${s.c * cMult} ${s.h})`
+  const lightText = (alpha?: number) => (alpha ? `oklch(0.95 0.012 ${s.h} / ${alpha})` : `oklch(0.95 0.012 ${s.h})`)
+
+  // Constants shared by both modes (raw brand/gray ramps don't mode-switch)
+  const constants = {
+    '--pal-t50': surfaceAt(0.988), // brand.200 / gray.50
+    '--pal-ghost': surfaceAt(0.962, 2), // brand.50 / gray.100 / menu tint
+    '--pal-ghost-2': surfaceAt(0.936, 3), // brand.100 / muted panels
+    '--pal-ink20': inkAt(0.24, 0.2),
+    '--pal-solid': inkAt(0.24),
+    '--pal-solid-hover': inkAt(0.32),
+    '--pal-solid-active': inkAt(0.29),
+    '--pal-dark-1': `oklch(0.22 0.012 ${ink.h})`, // dark body bg
+    '--pal-dark-2': `oklch(0.235 0.012 ${ink.h})`, // dark auth bg
+    '--pal-dark-menu': `oklch(0.25 0.013 ${ink.h})`, // dark sidebar/menu
+    '--pal-dark-3': `oklch(0.34 0.016 ${ink.h})`, // dark muted bg
+    '--pal-g200': surfaceAt(0.911, 2),
+    '--pal-g400': inkAt(0.72),
+    '--pal-g500': inkAt(0.55),
+    '--pal-g600': inkAt(0.45),
+    '--pal-g700': inkAt(0.35),
+    '--pal-g800': inkAt(0.27),
+  }
+
+  return {
+    id,
+    label,
+    swatch: { bg: surfaceAt(0.962, 2), accent: accent.light },
+    light: {
+      ...constants,
+      '--pal-bg': surfaceAt(0.988),
+      '--pal-menu': surfaceAt(0.962, 2),
+      '--pal-auth-bg': surfaceAt(0.936, 3),
+      '--pal-text': inkAt(0.24),
+      '--pal-text-strong': inkAt(0.24),
+      '--pal-text-64': inkAt(0.24, 0.64),
+      '--pal-placeholder': inkAt(0.24, 0.55),
+      '--pal-hairline': inkAt(0.24, 0.1),
+      '--pal-accent': accent.light,
+      '--pal-accent-hover': accent.lightHover,
+    },
+    dark: {
+      ...constants,
+      '--pal-bg': `oklch(0.22 0.012 ${ink.h})`,
+      '--pal-menu': `oklch(0.25 0.013 ${ink.h})`,
+      '--pal-auth-bg': `oklch(0.235 0.012 ${ink.h})`,
+      '--pal-text': lightText(),
+      '--pal-text-strong': lightText(0.8),
+      '--pal-text-64': lightText(0.66),
+      '--pal-placeholder': lightText(0.5),
+      '--pal-hairline': 'oklch(1 0 0 / 0.1)',
+      '--pal-accent': accent.dark,
+      '--pal-accent-hover': accent.darkHover,
+    },
+  }
+}
+
+/**
+ * Institutional-friendly lineup: sober near-white surfaces, hue-tinted ink,
+ * one restrained accent per palette. Targets orgs like professional bodies,
+ * municipalities and political parties — calm, trustworthy, no loud colors.
+ */
+export const palettes: Palette[] = [
+  build({
+    id: 'editorial',
+    label: 'Editorial',
+    surface: { h: 97, c: 0.011 },
+    ink: { h: 106, c: 0.013 },
+    accent: {
+      light: 'oklch(0.47 0.085 158)',
+      lightHover: 'oklch(0.4 0.08 158)',
+      dark: 'oklch(0.62 0.09 158)',
+      darkHover: 'oklch(0.7 0.09 158)',
+    },
+  }),
+  build({
+    id: 'navy',
+    label: 'Navy',
+    surface: { h: 250, c: 0.005 },
+    ink: { h: 255, c: 0.018 },
+    accent: {
+      light: 'oklch(0.38 0.09 258)',
+      lightHover: 'oklch(0.32 0.08 258)',
+      dark: 'oklch(0.68 0.09 255)',
+      darkHover: 'oklch(0.75 0.08 255)',
+    },
+  }),
+  build({
+    id: 'petrol',
+    label: 'Petrol',
+    surface: { h: 215, c: 0.007 },
+    ink: { h: 225, c: 0.016 },
+    accent: {
+      light: 'oklch(0.45 0.085 205)',
+      lightHover: 'oklch(0.38 0.08 205)',
+      dark: 'oklch(0.65 0.08 200)',
+      darkHover: 'oklch(0.72 0.08 200)',
+    },
+  }),
+  build({
+    id: 'burgundy',
+    label: 'Burgundy',
+    surface: { h: 75, c: 0.008 },
+    ink: { h: 30, c: 0.014 },
+    accent: {
+      light: 'oklch(0.4 0.115 20)',
+      lightHover: 'oklch(0.34 0.11 20)',
+      dark: 'oklch(0.64 0.12 18)',
+      darkHover: 'oklch(0.71 0.11 18)',
+    },
+  }),
+  build({
+    id: 'graphite',
+    label: 'Graphite',
+    surface: { h: 270, c: 0.002 },
+    ink: { h: 270, c: 0.005 },
+    accent: {
+      light: 'oklch(0.42 0.045 255)',
+      lightHover: 'oklch(0.35 0.045 255)',
+      dark: 'oklch(0.7 0.045 255)',
+      darkHover: 'oklch(0.77 0.04 255)',
+    },
+  }),
+  build({
+    id: 'sage',
+    label: 'Sage',
+    surface: { h: 140, c: 0.006 },
+    ink: { h: 150, c: 0.014 },
+    accent: {
+      light: 'oklch(0.42 0.07 150)',
+      lightHover: 'oklch(0.36 0.065 150)',
+      dark: 'oklch(0.66 0.07 150)',
+      darkHover: 'oklch(0.73 0.07 150)',
+    },
+  }),
+  build({
+    id: 'iris',
+    label: 'Iris',
+    surface: { h: 290, c: 0.005 },
+    ink: { h: 290, c: 0.016 },
+    accent: {
+      light: 'oklch(0.44 0.1 285)',
+      lightHover: 'oklch(0.38 0.095 285)',
+      dark: 'oklch(0.68 0.09 285)',
+      darkHover: 'oklch(0.75 0.085 285)',
+    },
+  }),
+  build({
+    id: 'slate',
+    label: 'Slate',
+    surface: { h: 240, c: 0.006 },
+    ink: { h: 245, c: 0.014 },
+    accent: {
+      light: 'oklch(0.45 0.07 235)',
+      lightHover: 'oklch(0.38 0.065 235)',
+      dark: 'oklch(0.68 0.07 235)',
+      darkHover: 'oklch(0.75 0.065 235)',
+    },
+  }),
+  build({
+    id: 'bronze',
+    label: 'Bronze',
+    surface: { h: 85, c: 0.01 },
+    ink: { h: 60, c: 0.014 },
+    accent: {
+      light: 'oklch(0.5 0.09 75)',
+      lightHover: 'oklch(0.43 0.085 75)',
+      dark: 'oklch(0.72 0.09 80)',
+      darkHover: 'oklch(0.78 0.085 80)',
+    },
+  }),
+  build({
+    id: 'teal',
+    label: 'Teal',
+    surface: { h: 190, c: 0.006 },
+    ink: { h: 200, c: 0.014 },
+    accent: {
+      light: 'oklch(0.46 0.08 185)',
+      lightHover: 'oklch(0.4 0.075 185)',
+      dark: 'oklch(0.66 0.08 185)',
+      darkHover: 'oklch(0.73 0.075 185)',
+    },
+  }),
+  build({
+    id: 'plum',
+    label: 'Plum',
+    surface: { h: 340, c: 0.006 },
+    ink: { h: 345, c: 0.014 },
+    accent: {
+      light: 'oklch(0.42 0.11 350)',
+      lightHover: 'oklch(0.36 0.105 350)',
+      dark: 'oklch(0.66 0.11 350)',
+      darkHover: 'oklch(0.73 0.1 350)',
+    },
+  }),
+  build({
+    id: 'moss',
+    label: 'Moss',
+    surface: { h: 110, c: 0.007 },
+    ink: { h: 120, c: 0.013 },
+    accent: {
+      light: 'oklch(0.44 0.075 128)',
+      lightHover: 'oklch(0.38 0.07 128)',
+      dark: 'oklch(0.66 0.075 128)',
+      darkHover: 'oklch(0.73 0.07 128)',
+    },
+  }),
+  build({
+    id: 'terracotta',
+    label: 'Terracotta',
+    surface: { h: 65, c: 0.009 },
+    ink: { h: 40, c: 0.014 },
+    accent: {
+      light: 'oklch(0.48 0.1 45)',
+      lightHover: 'oklch(0.42 0.095 45)',
+      dark: 'oklch(0.66 0.1 45)',
+      darkHover: 'oklch(0.73 0.095 45)',
+    },
+  }),
+]
+
+export const DEFAULT_PALETTE = palettes[0]
+
+/** Builds the globalCss selector map that defines every palette's vars. */
+export const paletteGlobalCss = () => {
+  const css: Record<string, Record<string, string>> = {
+    // Default (no data-palette attribute) = first palette
+    ':root': { ...DEFAULT_PALETTE.light },
+    'html.dark': { ...DEFAULT_PALETTE.dark },
+  }
+  for (const palette of palettes) {
+    css[`html[data-palette='${palette.id}']`] = { ...palette.light }
+    css[`html.dark[data-palette='${palette.id}']`] = { ...palette.dark }
+  }
+  return css
+}

--- a/src/theme/recipes/button.ts
+++ b/src/theme/recipes/button.ts
@@ -25,6 +25,8 @@ const listmenu = defineStyle({
   borderRadius: 'sm',
   _active: {
     fontWeight: 'bold',
+    bg: 'var(--pal-nav-active-bg)',
+    color: 'var(--pal-nav-active-fg)',
   },
   _hover: {
     bg: 'gray.100',

--- a/src/theme/recipes/typography.ts
+++ b/src/theme/recipes/typography.ts
@@ -31,13 +31,14 @@ export const heading = defineRecipe({
 
 export const link = defineRecipe({
   base: {
-    // Palette vars already switch between light/dark modes
-    color: 'var(--pal-accent)',
+    // Ink-colored links (editorial style) — accent is reserved for controls
+    // and highlights, never for content links. Vars switch light/dark modes.
+    color: 'var(--pal-text-strong)',
     textDecoration: 'underline',
     textDecorationThickness: 'from-font',
     textUnderlineOffset: '0.15em',
     _hover: {
-      color: 'var(--pal-accent-hover)',
+      color: 'var(--pal-text-64)',
     },
   },
   variants: {

--- a/src/theme/recipes/typography.ts
+++ b/src/theme/recipes/typography.ts
@@ -31,18 +31,13 @@ export const heading = defineRecipe({
 
 export const link = defineRecipe({
   base: {
-    color: 'oklch(0.47 0.085 158)',
+    // Palette vars already switch between light/dark modes
+    color: 'var(--pal-accent)',
     textDecoration: 'underline',
     textDecorationThickness: 'from-font',
     textUnderlineOffset: '0.15em',
-    _dark: {
-      color: 'oklch(0.62 0.09 158)',
-      _hover: {
-        color: 'oklch(0.7 0.09 158)',
-      },
-    },
     _hover: {
-      color: 'oklch(0.4 0.08 158)',
+      color: 'var(--pal-accent-hover)',
     },
   },
   variants: {

--- a/src/theme/recipes/typography.ts
+++ b/src/theme/recipes/typography.ts
@@ -12,11 +12,16 @@ const sidebarSubtitle = {
 export const heading = defineRecipe({
   base: {
     fontWeight: 'bold',
+    letterSpacing: '-0.03em',
+    lineHeight: 1.02,
+    // Fraunces variable axes: SOFT rounds the serifs, WONK off
+    fontVariationSettings: "'SOFT' 100, 'WONK' 0",
   },
   variants: {
     variant: {
       header: {
-        fontWeight: 'extrabold',
+        // Single-weight display serif: never heavier than 400
+        fontWeight: 'bold',
       },
       ['sidebar-title']: sidebarTitle,
       ['sidebar-subtitle']: sidebarSubtitle,
@@ -26,18 +31,18 @@ export const heading = defineRecipe({
 
 export const link = defineRecipe({
   base: {
-    color: 'gray.800',
+    color: 'oklch(0.47 0.085 158)',
     textDecoration: 'underline',
     textDecorationThickness: 'from-font',
     textUnderlineOffset: '0.15em',
     _dark: {
-      color: 'gray.400',
+      color: 'oklch(0.62 0.09 158)',
       _hover: {
-        color: 'gray.200',
+        color: 'oklch(0.7 0.09 158)',
       },
     },
     _hover: {
-      color: 'gray.500',
+      color: 'oklch(0.4 0.08 158)',
     },
   },
   variants: {

--- a/src/theme/semantic.ts
+++ b/src/theme/semantic.ts
@@ -64,6 +64,11 @@ export const colors = defineSemanticTokens.colors({
     },
   },
   card: {
+    // Generic elevated card surface (dashboard boxes). Flat with the canvas in
+    // most palettes; a distinct lighter surface where a palette opts in (Cloud).
+    surface: {
+      value: 'var(--pal-card)',
+    },
     pricing: {
       bg: {
         value: {

--- a/src/theme/semantic.ts
+++ b/src/theme/semantic.ts
@@ -9,7 +9,7 @@ const chakra = {
   body: {
     bg: {
       value: {
-        _light: '{colors.white}',
+        _light: 'oklch(0.988 0.011 97)',
         _dark: '{colors.brand.650}',
       },
     },
@@ -19,20 +19,20 @@ const chakra = {
 const texts = {
   primary: {
     value: {
-      _light: '{colors.brand.500}',
-      _dark: '{colors.white}',
+      _light: 'oklch(0.24 0.013 106)',
+      _dark: 'oklch(0.95 0.012 97)',
     },
   },
   subtle: {
     value: {
-      _light: '{colors.gray.500}',
-      _dark: '{colors.gray.400}',
+      _light: 'oklch(0.24 0.013 106 / 0.64)',
+      _dark: 'oklch(0.95 0.012 97 / 0.66)',
     },
   },
   dark: {
     value: {
-      _light: '{colors.gray.600}',
-      _dark: '{colors.gray.500}',
+      _light: 'oklch(0.24 0.013 106)',
+      _dark: 'oklch(0.95 0.012 97 / 0.8)',
     },
   },
 }
@@ -49,27 +49,27 @@ export const colors = defineSemanticTokens.colors({
   auth: {
     bg: {
       value: {
-        _light: '{colors.gray.50}',
+        _light: 'oklch(0.936 0.033 97)',
         _dark: '{colors.brand.550}',
       },
     },
     card: {
       bg: {
         value: {
-          _light: '{colors.white}',
+          _light: 'oklch(0.988 0.011 97)',
           _dark: '{colors.brand.500}',
         },
       },
       border: {
-        value: '{colors.gray.200}',
+        value: 'oklch(0.24 0.013 106 / 0.1)',
       },
     },
   },
   border: {
     dashboard: {
       value: {
-        _light: '{colors.gray.200}',
-        _dark: '{colors.gray.800}',
+        _light: 'oklch(0.24 0.013 106 / 0.1)',
+        _dark: 'oklch(1 0 0 / 0.1)',
       },
     },
     pagination: {
@@ -85,13 +85,13 @@ export const colors = defineSemanticTokens.colors({
     pricing: {
       bg: {
         value: {
-          _light: '{colors.white}',
+          _light: 'oklch(0.988 0.011 97)',
           _dark: '{colors.brand.650}',
         },
       },
       border: {
         value: {
-          _light: '{colors.gray.200}',
+          _light: 'oklch(0.24 0.013 106 / 0.1)',
           _dark: '{colors.brand.700}',
         },
       },
@@ -146,15 +146,18 @@ export const colors = defineSemanticTokens.colors({
   },
   input: {
     placeholder: {
-      value: '{colors.gray.500}',
+      value: {
+        _light: 'oklch(0.24 0.013 106 / 0.55)',
+        _dark: 'oklch(0.95 0.012 97 / 0.5)',
+      },
     },
   },
   // @deprecated: to be removed in favor of border.dashboard
   table: {
     border: {
       value: {
-        _light: '{colors.gray.200}',
-        _dark: '{colors.gray.800}',
+        _light: 'oklch(0.24 0.013 106 / 0.1)',
+        _dark: 'oklch(1 0 0 / 0.1)',
       },
     },
   },
@@ -162,20 +165,20 @@ export const colors = defineSemanticTokens.colors({
     tab: {
       color: {
         value: {
-          _light: '{colors.gray.500}',
-          _dark: '{colors.gray.400}',
+          _light: 'oklch(0.24 0.013 106 / 0.64)',
+          _dark: 'oklch(0.95 0.012 97 / 0.66)',
         },
       },
       active: {
         color: {
           value: {
             _light: '{colors.brand.500}',
-            _dark: '{colors.white}',
+            _dark: 'oklch(0.95 0.012 97)',
           },
         },
         bg: {
           value: {
-            _light: '{colors.white}',
+            _light: 'oklch(0.988 0.011 97)',
             _dark: '{colors.brand.500}',
           },
         },
@@ -183,7 +186,7 @@ export const colors = defineSemanticTokens.colors({
     },
     bg: {
       value: {
-        _light: '{colors.gray.100}',
+        _light: 'oklch(0.936 0.033 97)',
         _dark: '{colors.brand.700}',
       },
     },

--- a/src/theme/semantic.ts
+++ b/src/theme/semantic.ts
@@ -8,32 +8,20 @@ import { defineSemanticTokens } from '@chakra-ui/react'
 const chakra = {
   body: {
     bg: {
-      value: {
-        _light: 'oklch(0.988 0.011 97)',
-        _dark: '{colors.brand.650}',
-      },
+      value: 'var(--pal-bg)',
     },
   },
 }
 
 const texts = {
   primary: {
-    value: {
-      _light: 'oklch(0.24 0.013 106)',
-      _dark: 'oklch(0.95 0.012 97)',
-    },
+    value: 'var(--pal-text)',
   },
   subtle: {
-    value: {
-      _light: 'oklch(0.24 0.013 106 / 0.64)',
-      _dark: 'oklch(0.95 0.012 97 / 0.66)',
-    },
+    value: 'var(--pal-text-64)',
   },
   dark: {
-    value: {
-      _light: 'oklch(0.24 0.013 106)',
-      _dark: 'oklch(0.95 0.012 97 / 0.8)',
-    },
+    value: 'var(--pal-text-strong)',
   },
 }
 
@@ -48,29 +36,23 @@ export const colors = defineSemanticTokens.colors({
   },
   auth: {
     bg: {
-      value: {
-        _light: 'oklch(0.936 0.033 97)',
-        _dark: '{colors.brand.550}',
-      },
+      value: 'var(--pal-auth-bg)',
     },
     card: {
       bg: {
         value: {
-          _light: 'oklch(0.988 0.011 97)',
+          _light: 'var(--pal-t50)',
           _dark: '{colors.brand.500}',
         },
       },
       border: {
-        value: 'oklch(0.24 0.013 106 / 0.1)',
+        value: 'var(--pal-hairline)',
       },
     },
   },
   border: {
     dashboard: {
-      value: {
-        _light: 'oklch(0.24 0.013 106 / 0.1)',
-        _dark: 'oklch(1 0 0 / 0.1)',
-      },
+      value: 'var(--pal-hairline)',
     },
     pagination: {
       active: {
@@ -85,13 +67,13 @@ export const colors = defineSemanticTokens.colors({
     pricing: {
       bg: {
         value: {
-          _light: 'oklch(0.988 0.011 97)',
+          _light: 'var(--pal-t50)',
           _dark: '{colors.brand.650}',
         },
       },
       border: {
         value: {
-          _light: 'oklch(0.24 0.013 106 / 0.1)',
+          _light: 'var(--pal-hairline)',
           _dark: '{colors.brand.700}',
         },
       },
@@ -146,39 +128,30 @@ export const colors = defineSemanticTokens.colors({
   },
   input: {
     placeholder: {
-      value: {
-        _light: 'oklch(0.24 0.013 106 / 0.55)',
-        _dark: 'oklch(0.95 0.012 97 / 0.5)',
-      },
+      value: 'var(--pal-placeholder)',
     },
   },
   // @deprecated: to be removed in favor of border.dashboard
   table: {
     border: {
-      value: {
-        _light: 'oklch(0.24 0.013 106 / 0.1)',
-        _dark: 'oklch(1 0 0 / 0.1)',
-      },
+      value: 'var(--pal-hairline)',
     },
   },
   tabs: {
     tab: {
       color: {
-        value: {
-          _light: 'oklch(0.24 0.013 106 / 0.64)',
-          _dark: 'oklch(0.95 0.012 97 / 0.66)',
-        },
+        value: 'var(--pal-text-64)',
       },
       active: {
         color: {
           value: {
             _light: '{colors.brand.500}',
-            _dark: 'oklch(0.95 0.012 97)',
+            _dark: 'var(--pal-text)',
           },
         },
         bg: {
           value: {
-            _light: 'oklch(0.988 0.011 97)',
+            _light: 'var(--pal-t50)',
             _dark: '{colors.brand.500}',
           },
         },
@@ -186,7 +159,7 @@ export const colors = defineSemanticTokens.colors({
     },
     bg: {
       value: {
-        _light: 'oklch(0.936 0.033 97)',
+        _light: 'var(--pal-auth-bg)',
         _dark: '{colors.brand.700}',
       },
     },

--- a/src/theme/system.ts
+++ b/src/theme/system.ts
@@ -7,6 +7,18 @@ export const system = createSystem(defaultConfig, {
   globalCss: {
     html: {
       colorPalette: 'gray',
+      // Warm editorial experiment: real values for the previously-undefined shadow vars
+      '--box-shadow': '0px 1px 2px 0px rgb(0 0 0 / 0.08)',
+      '--box-shadow-banner':
+        '0px 12px 32px -8px oklch(0.24 0.013 106 / 0.16), 0px 2px 6px -2px oklch(0.24 0.013 106 / 0.08)',
+      '--box-shadow-dark-mode': '0px 1px 2px 0px rgb(0 0 0 / 0.25)',
+    },
+    body: {
+      bg: 'chakra.body.bg',
+      color: 'texts.primary',
+      WebkitFontSmoothing: 'antialiased',
+      MozOsxFontSmoothing: 'grayscale',
+      textRendering: 'optimizeLegibility',
     },
   },
   theme: {

--- a/src/theme/system.ts
+++ b/src/theme/system.ts
@@ -1,10 +1,12 @@
 import { createSystem, defaultConfig } from '@chakra-ui/react'
+import { paletteGlobalCss } from './palettes'
 import { recipes, slotRecipes } from './recipes'
 import semanticTokens from './semantic'
 import tokens from './tokens'
 
 export const system = createSystem(defaultConfig, {
   globalCss: {
+    ...paletteGlobalCss(),
     html: {
       colorPalette: 'gray',
       // Warm editorial experiment: real values for the previously-undefined shadow vars

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -4,8 +4,8 @@ import { colors } from './colors'
 const sidebarWidth = '350px'
 
 const fonts = defineTokens.fonts({
-  body: { value: `"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", sans-serif` },
-  heading: { value: `"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", sans-serif` },
+  body: { value: `'Hanken Grotesk Variable', -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif` },
+  heading: { value: `'Fraunces Variable', Georgia, serif` },
   mono: { value: `'Menlo', monospace` },
 })
 
@@ -19,13 +19,13 @@ const fontWeights = defineTokens.fontWeights({
 const radii = defineTokens.radii({
   none: { value: '0rem' },
   xxs: { value: '2px' },
-  xs: { value: '4px' },
-  sm: { value: '6px' },
-  md: { value: '8px' },
-  lg: { value: '10px' },
-  xl: { value: '12px' },
-  '2xl': { value: '16px' },
-  '3xl': { value: '20px' },
+  xs: { value: '6px' },
+  sm: { value: '8px' },
+  md: { value: '10px' },
+  lg: { value: '14px' },
+  xl: { value: '16px' },
+  '2xl': { value: '20px' },
+  '3xl': { value: '24px' },
   '4xl': { value: '24px' },
   full: { value: '9999px' },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,7 @@ const viteconfig = ({ mode }: { mode: string }) => {
     // command and its parser rejects unknown flags like `--host`/`--port`.
     server: {
       host: true,
+      port: process.env.DEV_PORT ? Number(process.env.DEV_PORT) : undefined,
     },
     build: {
       outDir,


### PR DESCRIPTION
## What this is

A **throwaway visual experiment** to explore a fresh look for the app and compare color directions with the team. Not intended to merge as-is — it's a playground branch so anyone can pull it, run locally, and click through 17 palettes live.

## What changed

- **Warm editorial theme**: Fraunces (serif headings) + Hanken Grotesk (body), cream/ink surfaces, hairline borders, soft shadows, larger radii. Pure token-layer swap — no component rewrites.
- **Inset dashboard layout**: the content area floats as a rounded, bordered panel over the sidebar background (shadcn-style inset sidebar).
- **Runtime palette switcher** in the dashboard sidebar (bottom, above the user menu): 17 institution-friendly palettes, sober near-white surfaces with one restrained accent each. Selection persists per browser via `localStorage`.
  - Crisp set: Editorial, Navy, Petrol, Burgundy, Graphite, Sage, Iris, Slate, Bronze, Teal, Plum, Moss, Terracotta
  - Softer / lower-glare set (warm off-white surfaces, gentler contrast): Sepia, Linen, Dusk, Fog

## How it works

Every themed color in the token layer is a `var(--pal-*)` reference; each palette defines those vars for light + dark under `html[data-palette='<id>']` selectors (see `src/theme/palettes.ts`). Switching a palette just sets `document.documentElement.dataset.palette`. Fonts are identical across palettes so the comparison is purely chromatic.

## Run it locally

```
git fetch origin
git checkout experiment/warm-editorial-theme
pnpm install
DEV_PORT=5299 pnpm dev
```

Log in, then use the **Theme preview** swatches at the bottom of the sidebar to switch palettes. Works in both light and dark mode.

## Notes / caveats

- Throwaway branch — lint, tests, translations and Chakra typegen were intentionally skipped.
- The switcher and demo palettes are meant to be deleted before any real theme work lands.
- The swatch label under the row only updates on an actual click (not when set programmatically).
