### PR TITLE
test: unflake the public-page redirect test, drop a never-emitted insight

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -59,7 +59,7 @@ Current taxonomy (PostHog names): `account_signed_up`, `user_logged_in`, `organi
 `billing_portal_opened`, `paywall_viewed`, `feature_blocked`, `process_creation_failed`,
 `process_template_selected`, `process_action`, `process_results_viewed`, `members_import_started`,
 `members_import_completed`, `member_group_created`, `member_group_deleted`, `census_configured`,
-`onboarding_step_completed`, `team_member_invited`, `team_member_removed`, `pdf_report_downloaded`.
+`team_member_invited`, `team_member_removed`, `pdf_report_downloaded`.
 
 Organization-level BI: every session registers `org_address`/`org_name`/`org_plan` super properties, and
 the `organization` group profile carries name, plan, type, country, size, usage counters, and renewal

--- a/scripts/posthog-insights.mjs
+++ b/scripts/posthog-insights.mjs
@@ -169,13 +169,6 @@ const buildPlan = (orgIndex) => {
           groupTypeIndex: byOrg,
         }),
         trend({
-          name: 'Onboarding steps completed',
-          description: 'Which setup checklist steps organizations actually finish. Drop-offs show the weakest step.',
-          series: [event('onboarding_step_completed', orgMath)],
-          breakdown: 'step',
-          display: 'ActionsBar',
-        }),
-        trend({
           name: 'Organizations created (by name)',
           description:
             'Who signed up, by name. `org_name` rides on the creation event itself, since the group profile is only registered once the organization has been fetched.',

--- a/src/pages/public-page-redirect.test.tsx
+++ b/src/pages/public-page-redirect.test.tsx
@@ -29,6 +29,15 @@ vi.mock('~elements/organization/PublicPage', () => ({
   default: () => <div>organization-page</div>,
 }))
 
+// Only reachable through `era === 'archive'`, which no test here exercises - but
+// the import is paid for regardless, and it drags in ~components/Editor and the
+// whole of Lexical. Left unmocked it made this file's second test ~17x slower
+// than the others and pushed it over vitest's 5s timeout under full-suite load.
+vi.mock('~components/Organization/Archive/View', () => ({
+  default: () => <div>archive-organization-page</div>,
+  ArchiveOrganizationView: () => <div>archive-organization-page</div>,
+}))
+
 vi.mock('~src/pages/shared/publicPageRedirect', () => ({
   usePreferredPublicLanguageRedirect,
 }))


### PR DESCRIPTION
Two unrelated maintenance fixes, split out of the cross-site analytics work so that PR stays reviewable. Neither depends on the other; both are independent of the analytics branches.

## 1. A dashboard chart for an event nothing emits

`onboarding_step_completed` was declared in the taxonomy by the PostHog integration and removed again in 3edf75591 — but it was **never emitted**. `git log -S"OnboardingStepCompleted"` across `src/components`, `src/pages` and `src/elements` returns nothing for the whole history.

So the "Onboarding steps completed" trend it feeds has rendered empty since the day it was provisioned, and `pnpm posthog:insights` would keep re-creating it on the Activation dashboard.

There is also nothing to instrument: "onboarding" in this product is the single "you have no organizations" screen, not a multi-step checklist, so a trend broken down by `step` describes a feature that does not exist. The activation funnel (signup → org → first election) already covers the ground.

Removes the insight and the stale taxonomy entry in the docs. If a real setup checklist ships later, the event and a trend for it can come back together.

> **Note:** the script only upserts, never deletes. If `pnpm posthog:insights` has already been run against the project, the empty chart still needs deleting by hand in PostHog.

## 2. A test importing Lexical inside a 5s timeout

`public-page-redirect.test.tsx` mocks every view the public pages render — except `~components/Organization/Archive/View`, which `PublicOrganizationPage` imports unconditionally. That view pulls in `~components/Editor` and with it the whole of Lexical (18 `@lexical/*` packages).

Two things turned that into a flake rather than merely slow:

1. The page module is brought in by a dynamic `import()` **inside the test body**, so the transform cost counts against vitest's 5s per-test timeout instead of collection.
2. The Lexical graph is only reachable through `era === 'archive'` — a branch **no test in the file renders**. It was paid for and thrown away.

Measured on an idle machine:

| test | before | after |
| --- | --- | --- |
| process page | 115ms | 114ms |
| **organization page** | **1977ms** | **14ms** |
| already-localized | 1ms | 1ms |
| file total | 2.76s | 767ms |

1977ms is already 40% of the budget with nothing else running; under full-suite load it crossed 5s and failed roughly two runs in three, surfacing as a bare `STACK_TRACE_ERROR` pointing at vitest's own runner rather than at any assertion.

No coverage is lost: the archive branch was never rendered, and the branch that *is* rendered goes through `~elements/organization/PublicPage`, already mocked.

## Testing

- `npx vitest run` — 734 passed, 0 failed, **3 consecutive runs** (against `develop`, which fails ~2 in 3)
- `npx tsc --noEmit` — clean
- `node scripts/posthog-insights.mjs --dry-run` — plan builds, no onboarding insight

🤖 Generated with [Claude Code](https://claude.com/claude-code)