### PR TITLE
feat(analytics): share identity with vocdoni.io

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -141,12 +141,12 @@ ingestion host.
 
 What it provisions:
 
-| Dashboard                  | Insights                                                                                                                                                                                                                                                                                                                                  |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Activation**             | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name                                                                                                                                                                                 |
-| **Monetization**           | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan                                                                                                                                                                                                          |
-| **Elections & engagement** | wizard funnel `process_template_selected` → `census_configured` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type`                                                                                                                                                |
-| **Web → app**              | website visit → CTA → signup → org → first election (by first-touch campaign); which vertical converts; blog and learn article → signup; sales assist `demo_requested` → `demo_booked` → subscription; marketing-sourced revenue; activation by locale; revenue by first-touch channel; event volume by `site`; CTA clicks by `page_type` |
+| Dashboard                  | Insights                                                                                                                                                                                                                                                                                                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Activation**             | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name                                                                                                                                                                                                           |
+| **Monetization**           | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan                                                                                                                                                                                                                                    |
+| **Elections & engagement** | wizard funnel `process_template_selected` → `census_configured` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type`                                                                                                                                                                          |
+| **Web → app**              | website visit → CTA → signup → org → first election (by first-touch campaign); which vertical converts; blog and learn article → signup; docs → integrator signup; sales assist `demo_requested` → `demo_booked` → subscription; marketing-sourced revenue; activation by locale; revenue by first-touch channel; event volume by `site`; CTA clicks by `page_type` |
 
 The **Web → app** dashboard is the one that needs both properties in the project. Every funnel on it
 stays **person-level**: the app funnels aggregate by the `organization` group, which is right for them,
@@ -158,12 +158,14 @@ touch rather than the app URL someone happened to land on.
 Run it once real cross-site traffic has landed; breakdowns on an empty project resolve to nothing and
 read as a broken dashboard.
 
-The docs → integrator funnel is absent for the same reason and no other: `platform.vocdoni.io` is not a
-separate property to onboard, it is this same deployment served under a second domain onto
-`/integrators`. It therefore already carries PostHog, and already shares the `.vocdoni.io` consent and
-`distinct_id` cookies, so a `docs_page_viewed` → `cta_clicked` (`target: 'platform'`) → integrator
-signup funnel only needs the events to exist. Note that `site` is `app` on both domains: integrator
-traffic is told apart by `$host` or by the `/integrators` path, not by `site`.
+`platform.vocdoni.io` needs no onboarding as a separate property: it is this same deployment served
+under a second domain onto `/integrators`, so it already carries PostHog and already shares the
+`.vocdoni.io` consent and `distinct_id` cookies. The docs → integrator funnel therefore works today.
+Its last step matches `account_signed_up` on `$pathname` containing `/integrators` rather than on
+`$host`, because those routes are reachable under both domains and integrator signup reuses
+`~components/Auth/SignUp` — so it emits the same `account_signed_up` as a regular signup, with nothing
+but the path to tell them apart. For the same reason `site` is `app` on both domains; integrator
+traffic is separated by path, not by `site`.
 
 Two things make the rest worth more than the PostHog defaults:
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -7,9 +7,9 @@ Plausible/GTM are kept for continuity.
 
 ## Configuration (runtime env)
 
-| Variable | Meaning |
-| --- | --- |
-| `POSTHOG_KEY` | PostHog project API key (`phc_…`). **Unset = PostHog fully disabled** (nothing is loaded). Set it in production only. |
+| Variable       | Meaning                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POSTHOG_KEY`  | PostHog project API key (`phc_…`). **Unset = PostHog fully disabled** (nothing is loaded). Set it in production only.                       |
 | `POSTHOG_HOST` | Defaults to `https://eu.i.posthog.com` (EU data residency). Point it at a reverse proxy later to mitigate ad-blockers without code changes. |
 
 Env is runtime-injected (see `src/app-env-build.ts`), so a single Docker image works across environments.
@@ -23,8 +23,8 @@ Env is runtime-injected (see `src/app-env-build.ts`), so a single Docker image w
      Voters never download the SDK.
    - `posthogBeforeSend` returns `null` for **any** event (pageviews, autocapture, replay snapshots,
      exceptions) whose URL is a voting route — covers admins SPA-navigating into a process view.
-   Consequently there are **no voter-side events** in the taxonomy; election participation BI comes from
-   admin-side events (`process_results_viewed`) and, later, the backend.
+     Consequently there are **no voter-side events** in the taxonomy; election participation BI comes from
+     admin-side events (`process_results_viewed`) and, later, the backend.
 2. **Cookieless until consent.** Before the cookie banner is accepted, PostHog runs with
    `persistence: 'memory'` (no cookies/localStorage) and anonymous events only
    (`person_profiles: 'identified_only'`). On accept: persistence upgrades and dashboard users are
@@ -34,7 +34,7 @@ Env is runtime-injected (see `src/app-env-build.ts`), so a single Docker image w
 4. **Session replay** only for authenticated users who accepted consent, with `maskAllInputs`; ballot
    content carries `.ph-no-capture` as defense in depth.
 5. **Memberbase PII is never recorded.** Every surface that renders a member record carries
-   `.ph-no-capture`, so rrweb skips the subtree entirely (text *and* attributes): member table cells
+   `.ph-no-capture`, so rrweb skips the subtree entirely (text _and_ attributes): member table cells
    (`Memberbase/Members/index.tsx`), member cards (`MemberCard.tsx` — the checkbox `aria-label`
    embeds the member name, so the whole card is excluded), group member table cells
    (`GroupsBoard.tsx`), and the CSV import error list (`Members/Import.tsx`), which quotes offending
@@ -45,6 +45,33 @@ Env is runtime-injected (see `src/app-env-build.ts`), so a single Docker image w
    personal data. `posthogMaskInput` (wired as `maskInputFn`) restores the value for inputs inside a
    `data-ph-unmask` subtree; passwords are never restored. The only current use is the organization
    name in Settings → Organization details (`Organization/Form.tsx`).
+
+## One project, two sites
+
+`vocdoni.io` (the marketing site, a separate repo) reports into **the same PostHog project** as this
+app. That is not a convenience: the free plan allows exactly one project, and PostHog cannot query
+across projects, so sharing one is the only way a funnel can start on a landing page and end at a
+subscription. Both sites ship the same `phc_…` key.
+
+What makes the two halves join up is a single `distinct_id` surviving the hop between subdomains:
+
+- posthog-js writes its persistence cookie with `cross_subdomain_cookie` (default `true` for
+  `vocdoni.io`), so the cookie is scoped to `.vocdoni.io`. The cookie name is derived from the project
+  token, and both sites use the same token, so they read and write the same cookie.
+- That only works while **both** sites run with cookie persistence, which only happens once consent is
+  known. So the consent choice itself lives in a cookie on `.vocdoni.io`
+  (`src/components/Cookies/utils.ts`), not in localStorage, which is per-origin. A per-origin choice
+  would leave this app in "no decision yet" for a visitor who already accepted on the website: it would
+  start in memory persistence, ignore the shared cookie, mint a fresh anonymous id, and every
+  website → app funnel would silently report near-zero. A pre-existing localStorage choice is migrated
+  on first read, so nobody is asked twice.
+- `identify()` on signup then merges that shared anonymous id into the person, so marketing pageviews
+  from before the account existed land in the same person's timeline.
+
+Events from the two sites are told apart by the `site` super property (`app` here, `web` on the
+marketing site), which is more durable than `$host` across preview hosts and custom domains.
+
+**Both sites must ship the consent cookie together.** Shipping only one leaves the bridge half-built.
 
 ## Tracking events
 
@@ -114,10 +141,10 @@ ingestion host.
 
 What it provisions:
 
-| Dashboard | Insights |
-| --- | --- |
-| **Activation** | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name |
-| **Monetization** | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan |
+| Dashboard                  | Insights                                                                                                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Activation**             | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name                                  |
+| **Monetization**           | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan                                                           |
 | **Elections & engagement** | wizard funnel `process_template_selected` → `census_configured` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type` |
 
 Two things make these worth more than the PostHog defaults:
@@ -163,4 +190,4 @@ Two gotchas when verifying:
   is true, which includes Playwright/Puppeteer even with a spoofed user agent and `navigator.webdriver`.
   The SDK still initializes and still calls `/flags/`, so it looks alive while `before_send` is never
   reached and no `/e/` request is ever made. Automated end-to-end checks need `opt_out_useragent_filter:
-  true` set temporarily, or a headed real browser.
+true` set temporarily, or a headed real browser.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -141,13 +141,31 @@ ingestion host.
 
 What it provisions:
 
-| Dashboard                  | Insights                                                                                                                                                                                   |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Activation**             | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name                                  |
-| **Monetization**           | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan                                                           |
-| **Elections & engagement** | wizard funnel `process_template_selected` → `census_configured` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type` |
+| Dashboard                  | Insights                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Activation**             | signup → org → first election (steps, time-to-convert, weekly trend); memberbase import funnel; onboarding steps completed; organizations created by name                                                                                                                                                                                 |
+| **Monetization**           | paywall → checkout → subscription (broken down by `source`); blocked feature → upgrade (by `feature`); paywall exposure per plan                                                                                                                                                                                                          |
+| **Elections & engagement** | wizard funnel `process_template_selected` → `census_configured` → `process_created` → `process_results_viewed`; created vs failed; weekly active organizations; elections by `census_type`                                                                                                                                                |
+| **Web → app**              | website visit → CTA → signup → org → first election (by first-touch campaign); which vertical converts; blog and learn article → signup; sales assist `demo_requested` → `demo_booked` → subscription; marketing-sourced revenue; activation by locale; revenue by first-touch channel; event volume by `site`; CTA clicks by `page_type` |
 
-Two things make these worth more than the PostHog defaults:
+The **Web → app** dashboard is the one that needs both properties in the project. Every funnel on it
+stays **person-level**: the app funnels aggregate by the `organization` group, which is right for them,
+but a website visitor has no organization yet, so group aggregation would drop step one and make the
+funnel look broken rather than empty. Campaign breakdowns use `$initial_utm_source` as a **person**
+property — because the anonymous id is created on the marketing site, that records the website's first
+touch rather than the app URL someone happened to land on.
+
+Run it once real cross-site traffic has landed; breakdowns on an empty project resolve to nothing and
+read as a broken dashboard.
+
+The docs → integrator funnel is absent for the same reason and no other: `platform.vocdoni.io` is not a
+separate property to onboard, it is this same deployment served under a second domain onto
+`/integrators`. It therefore already carries PostHog, and already shares the `.vocdoni.io` consent and
+`distinct_id` cookies, so a `docs_page_viewed` → `cta_clicked` (`target: 'platform'`) → integrator
+signup funnel only needs the events to exist. Note that `site` is `app` on both domains: integrator
+traffic is told apart by `$host` or by the `/integrators` path, not by `site`.
+
+Two things make the rest worth more than the PostHog defaults:
 
 - **Organization-level aggregation.** Every funnel that starts after an org exists sets
   `aggregation_group_type_index` to the `organization` group, so conversion counts organizations, not

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -209,5 +209,5 @@ Two gotchas when verifying:
 - **Headless browsers capture nothing.** posthog-js drops every event when its internal `_is_bot()` check
   is true, which includes Playwright/Puppeteer even with a spoofed user agent and `navigator.webdriver`.
   The SDK still initializes and still calls `/flags/`, so it looks alive while `before_send` is never
-  reached and no `/e/` request is ever made. Automated end-to-end checks need `opt_out_useragent_filter:
-true` set temporarily, or a headed real browser.
+  reached and no `/e/` request is ever made. Automated end-to-end checks need
+  `opt_out_useragent_filter: true` set temporarily, or a headed real browser.

--- a/scripts/posthog-insights.mjs
+++ b/scripts/posthog-insights.mjs
@@ -57,6 +57,13 @@ const apiList = async (path) => {
 
 const event = (name, extra = {}) => ({ kind: 'EventsNode', event: name, name, ...extra })
 
+/** An event step narrowed to one property value, e.g. only pageviews on the marketing site. */
+const eventWhere = (name, key, value, label) =>
+  event(name, {
+    ...(label ? { custom_name: label } : {}),
+    properties: [{ key, value, operator: 'exact', type: 'event' }],
+  })
+
 /**
  * `aggregation_group_type_index` makes a funnel count organizations instead of
  * people — the right unit for a B2B product, where several colleagues share one
@@ -71,6 +78,7 @@ const funnel = ({
   windowUnit = 'day',
   vizType = 'steps',
   breakdown = null,
+  breakdownType = 'event',
   dateFrom = '-90d',
   extraFilter = {},
 }) => ({
@@ -84,7 +92,7 @@ const funnel = ({
       dateRange: { date_from: dateFrom },
       filterTestAccounts: true,
       ...(groupTypeIndex === null ? {} : { aggregation_group_type_index: groupTypeIndex }),
-      ...(breakdown ? { breakdownFilter: { breakdown, breakdown_type: 'event' } } : {}),
+      ...(breakdown ? { breakdownFilter: { breakdown, breakdown_type: breakdownType } } : {}),
       funnelsFilter: {
         funnelOrderType: 'ordered',
         funnelVizType: vizType,
@@ -206,6 +214,117 @@ const buildPlan = (orgIndex) => {
           description: 'How often each plan hits a wall — sustained pressure on one plan is a packaging signal.',
           series: [event('feature_blocked', orgMath)],
           breakdown: 'plan',
+          display: 'ActionsBar',
+        }),
+      ],
+    },
+    {
+      dashboard: {
+        name: 'Vocdoni · Web → app',
+        description:
+          'What the marketing site actually produces. vocdoni.io and this app report into one PostHog project, so these funnels can cross the domain boundary.',
+      },
+      // Every funnel here stays person-level. The existing app funnels aggregate
+      // by the `organization` group, which is right for them — but a website
+      // visitor has no organization yet, so group aggregation would drop step
+      // one and make the funnel look broken rather than empty.
+      insights: [
+        funnel({
+          name: 'Web → app · website visit to first election',
+          description:
+            "The headline number: what share of website traffic ends in a published election. Broken down by the campaign that produced the first visit — because the anonymous id is created on the website, `$initial_utm_source` records the website's first touch, not the app's landing URL.",
+          steps: [
+            eventWhere('$pageview', '$host', 'vocdoni.io', 'Pageview on vocdoni.io'),
+            eventWhere('cta_clicked', 'target', 'app', 'CTA into the app'),
+            'account_signed_up',
+            'organization_created',
+            'process_created',
+          ],
+          breakdown: '$initial_utm_source',
+          breakdownType: 'person',
+        }),
+        funnel({
+          name: 'Web → app · which vertical converts',
+          description:
+            'Ten solution pages compete for the same effort. This ranks them by customers produced rather than sessions received, and the two rankings are rarely the same.',
+          steps: ['solution_page_viewed', 'cta_clicked', 'account_signed_up', 'process_created'],
+          breakdown: 'vertical',
+        }),
+        funnel({
+          name: 'Web → app · blog post to signup',
+          description:
+            'Which article pays for itself. The 7-day window is deliberately tight: content that converts a month later is really being credited to something else.',
+          steps: ['blog_post_viewed', 'cta_clicked', 'account_signed_up'],
+          windowInterval: 7,
+          breakdown: 'slug',
+        }),
+        funnel({
+          name: 'Web → app · learn article to signup',
+          description:
+            'The same question for the evergreen guides, which have a different intent profile from the blog. Separate from the blog funnel because a funnel step is a single event.',
+          steps: ['learn_article_viewed', 'cta_clicked', 'account_signed_up'],
+          windowInterval: 7,
+          breakdown: 'slug',
+        }),
+        funnel({
+          name: 'Web → app · sales assist',
+          description:
+            'Puts a conversion rate on the Cal.com booking flow and, at the last step, a value on a booked call. A wide gap between requested and booked points at the booking widget itself.',
+          steps: ['demo_requested', 'demo_booked', 'account_signed_up', 'subscription_completed'],
+          windowInterval: 90,
+          breakdown: 'location',
+        }),
+        funnel({
+          name: 'Web → app · marketing-sourced revenue',
+          description:
+            'The money question, end to end, attributed to the campaign that started the journey rather than to the app URL the visitor happened to land on.',
+          steps: [
+            eventWhere('$pageview', '$host', 'vocdoni.io', 'Pageview on vocdoni.io'),
+            'account_signed_up',
+            'process_created',
+            'paywall_viewed',
+            'checkout_started',
+            'subscription_completed',
+          ],
+          windowInterval: 90,
+          breakdown: '$initial_utm_source',
+          breakdownType: 'person',
+        }),
+        funnel({
+          name: 'Web → app · activation by locale',
+          description:
+            'Eleven locales are maintained under a strict translation guardrail. This is what that investment returns per language; a locale converting far below its traffic share is usually a copy problem, not a demand problem.',
+          steps: [
+            eventWhere('$pageview', '$host', 'vocdoni.io', 'Pageview on vocdoni.io'),
+            'cta_clicked',
+            'account_signed_up',
+            'organization_created',
+          ],
+          breakdown: 'locale',
+        }),
+        trend({
+          name: 'Revenue by first-touch channel',
+          description:
+            'Subscriptions attributed to the campaign that produced the very first visit. Needs no tagging discipline beyond UTMs on inbound links.',
+          series: [event('subscription_completed')],
+          breakdown: '$initial_utm_source',
+          breakdownType: 'person',
+          display: 'ActionsTable',
+        }),
+        trend({
+          name: 'Event volume by site',
+          description:
+            'Both properties share one project and one 1M/month allowance. This is the split, and the early warning if the website starts eating the budget.',
+          series: [event(null, { name: 'All events' })],
+          breakdown: 'site',
+          display: 'ActionsBar',
+        }),
+        trend({
+          name: 'CTA clicks by page type',
+          description:
+            'Where intent actually happens on the marketing site. Reads off the `page_type` property, which is resolved at click time from the route.',
+          series: [event('cta_clicked')],
+          breakdown: 'page_type',
           display: 'ActionsBar',
         }),
       ],

--- a/scripts/posthog-insights.mjs
+++ b/scripts/posthog-insights.mjs
@@ -58,10 +58,10 @@ const apiList = async (path) => {
 const event = (name, extra = {}) => ({ kind: 'EventsNode', event: name, name, ...extra })
 
 /** An event step narrowed to one property value, e.g. only pageviews on the marketing site. */
-const eventWhere = (name, key, value, label) =>
+const eventWhere = (name, key, value, label, operator = 'exact') =>
   event(name, {
     ...(label ? { custom_name: label } : {}),
-    properties: [{ key, value, operator: 'exact', type: 'event' }],
+    properties: [{ key, value, operator, type: 'event' }],
   })
 
 /**
@@ -301,6 +301,18 @@ const buildPlan = (orgIndex) => {
             'organization_created',
           ],
           breakdown: 'locale',
+        }),
+        funnel({
+          name: 'Web → app · docs to integrator signup',
+          description:
+            'platform.vocdoni.io is this app under a second domain, onto /integrators, so integrator signups already land in this project. The last step matches on $pathname rather than $host, because the same routes are reachable on app.vocdoni.io too. 14-day window: reading the docs and deciding to build is not a same-session decision.',
+          steps: [
+            'docs_page_viewed',
+            eventWhere('cta_clicked', 'target', 'platform', 'CTA into the integrator dashboard'),
+            eventWhere('account_signed_up', '$pathname', '/integrators', 'Integrator signup', 'icontains'),
+          ],
+          windowInterval: 14,
+          breakdown: 'slug',
         }),
         trend({
           name: 'Revenue by first-touch channel',

--- a/scripts/posthog-insights.mjs
+++ b/scripts/posthog-insights.mjs
@@ -64,6 +64,13 @@ const eventWhere = (name, key, value, label, operator = 'exact') =>
     properties: [{ key, value, operator, type: 'event' }],
   })
 
+// Shared first step of the cross-site funnels. Anchored on `$host` (always
+// present) rather than the `site` super property because `site: 'web'` only
+// exists once the marketing repo ships its registration — migrate this to
+// `site = 'web'` at that point, and it will also stop under-counting if the
+// website ever serves under www. or a custom domain.
+const webPageview = eventWhere('$pageview', '$host', 'vocdoni.io', 'Pageview on vocdoni.io')
+
 /**
  * `aggregation_group_type_index` makes a funnel count organizations instead of
  * people — the right unit for a B2B product, where several colleagues share one
@@ -234,7 +241,7 @@ const buildPlan = (orgIndex) => {
           description:
             "The headline number: what share of website traffic ends in a published election. Broken down by the campaign that produced the first visit — because the anonymous id is created on the website, `$initial_utm_source` records the website's first touch, not the app's landing URL.",
           steps: [
-            eventWhere('$pageview', '$host', 'vocdoni.io', 'Pageview on vocdoni.io'),
+            webPageview,
             eventWhere('cta_clicked', 'target', 'app', 'CTA into the app'),
             'account_signed_up',
             'organization_created',
@@ -279,7 +286,7 @@ const buildPlan = (orgIndex) => {
           description:
             'The money question, end to end, attributed to the campaign that started the journey rather than to the app URL the visitor happened to land on.',
           steps: [
-            eventWhere('$pageview', '$host', 'vocdoni.io', 'Pageview on vocdoni.io'),
+            webPageview,
             'account_signed_up',
             'process_created',
             'paywall_viewed',
@@ -295,7 +302,7 @@ const buildPlan = (orgIndex) => {
           description:
             'Eleven locales are maintained under a strict translation guardrail. This is what that investment returns per language; a locale converting far below its traffic share is usually a copy problem, not a demand problem.',
           steps: [
-            eventWhere('$pageview', '$host', 'vocdoni.io', 'Pageview on vocdoni.io'),
+            webPageview,
             'cta_clicked',
             'account_signed_up',
             'organization_created',

--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useSaasAccount } from '~components/Account/SaasAccountProvider'
 import { useSubscription } from '~components/Auth/Subscription'
 import { useAuth } from '~components/Auth/useAuth'
-import { COOKIE_CONSENT_CHANGE_EVENT, getCookieConsent } from '~components/Cookies/utils'
+import { COOKIE_CONSENT_CHANGE_EVENT, getCookieConsent, watchCrossSiteConsent } from '~components/Cookies/utils'
 import { useProfile } from '~queries/account'
 import { useAppEnv } from '~src/app-env'
 import {
@@ -17,7 +17,6 @@ import {
   resetPosthogUser,
   setPosthogOrganization,
   setPosthogSessionRecording,
-  toPosthogConsent,
   trackAnalyticsEvent,
   trackGTMEvent,
   trackPlausibleEvent,
@@ -38,12 +37,18 @@ const useAnalyticsProvider = () => {
   const { organization } = useSaasAccount()
   const { subscription } = useSubscription()
   const { i18n } = useTranslation()
-  const [consent, setConsent] = useState<PosthogConsent>(() => toPosthogConsent(getCookieConsent()))
+  const [consent, setConsent] = useState<PosthogConsent>(() => getCookieConsent())
 
   useEffect(() => {
-    const syncConsent = () => setConsent(toPosthogConsent(getCookieConsent()))
+    const syncConsent = () => setConsent(getCookieConsent())
     window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, syncConsent)
-    return () => window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, syncConsent)
+    // The consent cookie has a second writer (vocdoni.io); re-check it on
+    // refocus so a revocation made over there stops tracking here mid-session.
+    const unwatch = watchCrossSiteConsent()
+    return () => {
+      window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, syncConsent)
+      unwatch()
+    }
   }, [])
 
   useEffect(() => {
@@ -69,14 +74,15 @@ const useAnalyticsProvider = () => {
     setPosthogSessionRecording(consent === 'accepted' && isAuthenticated)
   }, [consent, isAuthenticated])
 
-  // Keep the interface locale attached to every event, and mark which property
-  // the event came from: this app and vocdoni.io report into a single PostHog
-  // project (the free plan allows one, and PostHog cannot query across
-  // projects), so `site` is what separates them in a filter. It is more durable
-  // than `$host`, which changes with preview hosts and custom domains.
+  // Keep the interface locale attached to every event. The `site` super
+  // property that separates this app from vocdoni.io in the shared PostHog
+  // project is registered inside initializePosthog, so it cannot miss an init
+  // retry the way an effect with i18n-only deps would.
   useEffect(() => {
     const locale = i18n.resolvedLanguage || i18n.language
-    registerPosthogSuperProperties({ site: 'app', ...(locale ? { locale } : {}) })
+    if (locale) {
+      registerPosthogSuperProperties({ locale })
+    }
   }, [i18n.resolvedLanguage, i18n.language])
 
   // Identify dashboard users only after explicit cookie consent; anonymous

--- a/src/components/AnalyticsProvider.tsx
+++ b/src/components/AnalyticsProvider.tsx
@@ -69,12 +69,14 @@ const useAnalyticsProvider = () => {
     setPosthogSessionRecording(consent === 'accepted' && isAuthenticated)
   }, [consent, isAuthenticated])
 
-  // Keep the interface locale attached to every event
+  // Keep the interface locale attached to every event, and mark which property
+  // the event came from: this app and vocdoni.io report into a single PostHog
+  // project (the free plan allows one, and PostHog cannot query across
+  // projects), so `site` is what separates them in a filter. It is more durable
+  // than `$host`, which changes with preview hosts and custom domains.
   useEffect(() => {
     const locale = i18n.resolvedLanguage || i18n.language
-    if (locale) {
-      registerPosthogSuperProperties({ locale })
-    }
+    registerPosthogSuperProperties({ site: 'app', ...(locale ? { locale } : {}) })
   }, [i18n.resolvedLanguage, i18n.language])
 
   // Identify dashboard users only after explicit cookie consent; anonymous

--- a/src/components/Cookies/utils.test.ts
+++ b/src/components/Cookies/utils.test.ts
@@ -89,6 +89,16 @@ describe('getCookieConsent', () => {
     expect(getCookieConsent()).toBe('rejected')
   })
 
+  it('refreshes the mirror when the other site changed the choice', () => {
+    // vocdoni.io can only write the shared cookie; this origin's localStorage
+    // would otherwise keep a revoked decision alive across a rollback.
+    setCookieConsent(true)
+    document.cookie = 'vocdoni-cookie-consent=rejected; Path=/'
+
+    expect(getCookieConsent()).toBe('rejected')
+    expect(localStorage.getItem('vocdoni-cookie-consent')).toBe('rejected')
+  })
+
   it('returns null when no choice has been made', () => {
     expect(getCookieConsent()).toBeNull()
   })

--- a/src/components/Cookies/utils.test.ts
+++ b/src/components/Cookies/utils.test.ts
@@ -53,6 +53,11 @@ describe('readConsentCookie', () => {
     expect(readConsentCookie(undefined)).toBeNull()
     expect(readConsentCookie('foo=1')).toBeNull()
   })
+
+  it('survives a malformed percent-escape instead of throwing', () => {
+    // Consent is read while rendering, so a URIError here would take the app down.
+    expect(readConsentCookie('vocdoni-cookie-consent=%E0%A4%A')).toBeNull()
+  })
 })
 
 describe('getCookieConsent', () => {
@@ -86,5 +91,20 @@ describe('getCookieConsent', () => {
 
   it('returns null when no choice has been made', () => {
     expect(getCookieConsent()).toBeNull()
+  })
+
+  it('ignores an unrecognised legacy value rather than promoting it to the shared cookie', () => {
+    localStorage.setItem('vocdoni-cookie-consent', 'true')
+
+    expect(getCookieConsent()).toBeNull()
+    expect(document.cookie).not.toContain('vocdoni-cookie-consent=true')
+  })
+
+  it('ignores an unrecognised cookie value and repairs it from a valid legacy choice', () => {
+    document.cookie = 'vocdoni-cookie-consent=true; Path=/'
+    localStorage.setItem('vocdoni-cookie-consent', 'accepted')
+
+    expect(getCookieConsent()).toBe('accepted')
+    expect(readConsentCookie(document.cookie)).toBe('accepted')
   })
 })

--- a/src/components/Cookies/utils.test.ts
+++ b/src/components/Cookies/utils.test.ts
@@ -1,5 +1,13 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { buildConsentCookie, consentCookieDomain, getCookieConsent, readConsentCookie, setCookieConsent } from './utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildConsentCookie,
+  consentCookieDomain,
+  COOKIE_CONSENT_CHANGE_EVENT,
+  getCookieConsent,
+  readConsentCookie,
+  setCookieConsent,
+  watchCrossSiteConsent,
+} from './utils'
 
 const clearConsentCookie = () => {
   document.cookie = 'vocdoni-cookie-consent=; Path=/; Max-Age=0'
@@ -57,6 +65,12 @@ describe('readConsentCookie', () => {
   it('survives a malformed percent-escape instead of throwing', () => {
     // Consent is read while rendering, so a URIError here would take the app down.
     expect(readConsentCookie('vocdoni-cookie-consent=%E0%A4%A')).toBeNull()
+  })
+
+  it('skips an unrecognised duplicate so it cannot shadow the real decision', () => {
+    // A junk host-only cookie can precede the Domain=.vocdoni.io one in the
+    // header, and a Domain= write can never replace a host-only cookie.
+    expect(readConsentCookie('vocdoni-cookie-consent=true; vocdoni-cookie-consent=accepted')).toBe('accepted')
   })
 })
 
@@ -116,5 +130,55 @@ describe('getCookieConsent', () => {
 
     expect(getCookieConsent()).toBe('accepted')
     expect(readConsentCookie(document.cookie)).toBe('accepted')
+  })
+
+  it('does not resurrect a decision after the shared cookie is deleted', () => {
+    // Clearing cookies is a legitimate consent withdrawal (and Safari expires
+    // script-written cookies on its own); the localStorage mirror must not
+    // silently re-mint the domain-wide cookie.
+    setCookieConsent(true)
+    clearConsentCookie()
+
+    expect(getCookieConsent()).toBeNull()
+    expect(document.cookie).not.toContain('vocdoni-cookie-consent=accepted')
+  })
+})
+
+describe('watchCrossSiteConsent', () => {
+  beforeEach(() => {
+    clearConsentCookie()
+    localStorage.clear()
+  })
+
+  it('dispatches the change event when the other site changed the cookie', () => {
+    // vocdoni.io can only write the shared cookie; without this, a revocation
+    // made over there would keep tracking alive here until a full reload.
+    setCookieConsent(true)
+    const unwatch = watchCrossSiteConsent()
+    const listener = vi.fn()
+    window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, listener)
+
+    document.cookie = 'vocdoni-cookie-consent=rejected; Path=/'
+    window.dispatchEvent(new Event('focus'))
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(getCookieConsent()).toBe('rejected')
+
+    window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, listener)
+    unwatch()
+  })
+
+  it('stays quiet when nothing changed on refocus', () => {
+    setCookieConsent(true)
+    const unwatch = watchCrossSiteConsent()
+    const listener = vi.fn()
+    window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, listener)
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(listener).not.toHaveBeenCalled()
+
+    window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, listener)
+    unwatch()
   })
 })

--- a/src/components/Cookies/utils.test.ts
+++ b/src/components/Cookies/utils.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { buildConsentCookie, consentCookieDomain, getCookieConsent, readConsentCookie, setCookieConsent } from './utils'
+
+const clearConsentCookie = () => {
+  document.cookie = 'vocdoni-cookie-consent=; Path=/; Max-Age=0'
+}
+
+describe('consentCookieDomain', () => {
+  it('scopes the choice to the domain shared with the marketing site', () => {
+    expect(consentCookieDomain('app.vocdoni.io')).toBe('.vocdoni.io')
+    expect(consentCookieDomain('vocdoni.io')).toBe('.vocdoni.io')
+  })
+
+  it('keeps local and preview hosts host-only, so they never join production identities', () => {
+    expect(consentCookieDomain('localhost')).toBeNull()
+    expect(consentCookieDomain('app.stg.vocdoni.net')).toBeNull()
+  })
+
+  it('does not match a lookalike domain that merely ends in the same characters', () => {
+    expect(consentCookieDomain('notvocdoni.io')).toBeNull()
+    expect(consentCookieDomain('vocdoni.io.evil.com')).toBeNull()
+  })
+})
+
+describe('buildConsentCookie', () => {
+  it('sets the shared domain and marks the cookie secure over https', () => {
+    const cookie = buildConsentCookie('accepted', 'app.vocdoni.io', 'https:')
+
+    expect(cookie).toContain('vocdoni-cookie-consent=accepted')
+    expect(cookie).toContain('Domain=.vocdoni.io')
+    expect(cookie).toContain('SameSite=Lax')
+    expect(cookie).toContain('Secure')
+  })
+
+  it('omits the domain and the secure flag on plain-http localhost', () => {
+    const cookie = buildConsentCookie('rejected', 'localhost', 'http:')
+
+    expect(cookie).not.toContain('Domain=')
+    expect(cookie).not.toContain('Secure')
+  })
+})
+
+describe('readConsentCookie', () => {
+  it('reads the value out of a cookie string holding other entries', () => {
+    expect(readConsentCookie('foo=1; vocdoni-cookie-consent=accepted; ph_test=2')).toBe('accepted')
+  })
+
+  it('does not match a cookie whose name merely ends with the key', () => {
+    expect(readConsentCookie('other-vocdoni-cookie-consent=accepted')).toBeNull()
+  })
+
+  it('handles an absent cookie header', () => {
+    expect(readConsentCookie(undefined)).toBeNull()
+    expect(readConsentCookie('foo=1')).toBeNull()
+  })
+})
+
+describe('getCookieConsent', () => {
+  beforeEach(() => {
+    clearConsentCookie()
+    localStorage.clear()
+  })
+
+  it('reads the choice back from the cookie', () => {
+    setCookieConsent(true)
+
+    expect(getCookieConsent()).toBe('accepted')
+    expect(document.cookie).toContain('vocdoni-cookie-consent=accepted')
+  })
+
+  it('honours a pre-existing localStorage choice and promotes it to the shared cookie', () => {
+    // Anyone who decided before this change must not be asked a second time.
+    localStorage.setItem('vocdoni-cookie-consent', 'accepted')
+
+    expect(getCookieConsent()).toBe('accepted')
+    expect(readConsentCookie(document.cookie)).toBe('accepted')
+  })
+
+  it('prefers the shared cookie over a stale localStorage mirror', () => {
+    // The other site is the one that may have changed the choice most recently.
+    setCookieConsent(false)
+    localStorage.setItem('vocdoni-cookie-consent', 'accepted')
+
+    expect(getCookieConsent()).toBe('rejected')
+  })
+
+  it('returns null when no choice has been made', () => {
+    expect(getCookieConsent()).toBeNull()
+  })
+})

--- a/src/components/Cookies/utils.ts
+++ b/src/components/Cookies/utils.ts
@@ -3,24 +3,100 @@ import TagManager from 'react-gtm-module'
 const CONSENT_KEY = 'vocdoni-cookie-consent'
 const CONSENT_ACCEPTED = 'accepted'
 const CONSENT_REJECTED = 'rejected'
+const CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 export const COOKIE_CONSENT_CHANGE_EVENT = 'vocdoni-cookie-consent-change'
 
 /**
- * Get the current cookie consent status from localStorage
+ * The registrable domain the app shares with the marketing site. The consent
+ * choice is stored as a cookie scoped to it - not in localStorage, which is
+ * per-origin - so that a visitor who accepted on `vocdoni.io` arrives here
+ * already decided.
+ *
+ * Analytics depends on that sharing. PostHog only keeps one `distinct_id`
+ * across subdomains while both sites run with cookie persistence, and both only
+ * switch to cookie persistence once consent is known. A per-origin choice leaves
+ * this app in "no decision yet", where it ignores the shared cookie and mints a
+ * fresh anonymous id - breaking every website -> app funnel at the first step.
+ */
+const ROOT_DOMAIN = 'vocdoni.io'
+
+/**
+ * Hosts outside `vocdoni.io` - localhost, staging, preview deploys - get a
+ * host-only cookie, so they never join production identities.
+ */
+export function consentCookieDomain(hostname: string): string | null {
+  if (hostname === ROOT_DOMAIN || hostname.endsWith(`.${ROOT_DOMAIN}`)) return `.${ROOT_DOMAIN}`
+  return null
+}
+
+export function buildConsentCookie(value: string, hostname: string, protocol: string): string {
+  const domain = consentCookieDomain(hostname)
+  return [
+    `${CONSENT_KEY}=${encodeURIComponent(value)}`,
+    'Path=/',
+    `Max-Age=${CONSENT_MAX_AGE_SECONDS}`,
+    'SameSite=Lax',
+    ...(domain ? [`Domain=${domain}`] : []),
+    ...(protocol === 'https:' ? ['Secure'] : []),
+  ].join('; ')
+}
+
+export function readConsentCookie(cookie: string | undefined): string | null {
+  if (!cookie) return null
+
+  for (const entry of cookie.split(';')) {
+    const separator = entry.indexOf('=')
+    if (separator === -1) continue
+    if (entry.slice(0, separator).trim() !== CONSENT_KEY) continue
+    return decodeURIComponent(entry.slice(separator + 1).trim()) || null
+  }
+  return null
+}
+
+function readLegacyConsent(): string | null {
+  try {
+    return localStorage.getItem(CONSENT_KEY)
+  } catch {
+    // Safari private mode and storage-blocking extensions throw on access.
+    return null
+  }
+}
+
+function writeConsent(value: string): void {
+  document.cookie = buildConsentCookie(value, window.location.hostname, window.location.protocol)
+  try {
+    // Mirrored, not read first: keeps a rollback of either site working, since
+    // the previous implementation only ever looked at localStorage.
+    localStorage.setItem(CONSENT_KEY, value)
+  } catch {
+    // The cookie above is the source of truth; losing the mirror is harmless.
+  }
+}
+
+/**
+ * Get the current cookie consent status
  * @returns 'accepted', 'rejected', or null if no choice has been made
  */
 export function getCookieConsent(): string | null {
   if (typeof window === 'undefined') return null
-  return localStorage.getItem(CONSENT_KEY)
+
+  const fromCookie = readConsentCookie(document.cookie)
+  if (fromCookie) return fromCookie
+
+  // Choices made before the shared cookie existed live in localStorage. Honour
+  // one once and promote it, so nobody who already decided is asked again.
+  const legacy = readLegacyConsent()
+  if (legacy) writeConsent(legacy)
+  return legacy
 }
 
 /**
- * Set the cookie consent status in localStorage
+ * Set the cookie consent status
  * @param accepted - true if user accepted cookies, false if rejected
  */
 export function setCookieConsent(accepted: boolean): void {
   if (typeof window === 'undefined') return
-  localStorage.setItem(CONSENT_KEY, accepted ? CONSENT_ACCEPTED : CONSENT_REJECTED)
+  writeConsent(accepted ? CONSENT_ACCEPTED : CONSENT_REJECTED)
   window.dispatchEvent(new Event(COOKIE_CONSENT_CHANGE_EVENT))
 }
 

--- a/src/components/Cookies/utils.ts
+++ b/src/components/Cookies/utils.ts
@@ -1,10 +1,20 @@
 import TagManager from 'react-gtm-module'
+import { readCookieValues } from '~utils/cookies'
 
 const CONSENT_KEY = 'vocdoni-cookie-consent'
 const CONSENT_ACCEPTED = 'accepted'
 const CONSENT_REJECTED = 'rejected'
+/**
+ * Set alongside the localStorage mirror the first time a value passes through
+ * the cookie era. An absent cookie next to a marked mirror means the cookie
+ * expired or was deliberately removed (a withdrawal), NOT a pre-migration
+ * choice - so it must never be promoted back to the shared domain.
+ */
+const CONSENT_MIGRATED_KEY = 'vocdoni-cookie-consent-migrated'
 const CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 export const COOKIE_CONSENT_CHANGE_EVENT = 'vocdoni-cookie-consent-change'
+
+export type ConsentValue = typeof CONSENT_ACCEPTED | typeof CONSENT_REJECTED
 
 /**
  * The registrable domain the app shares with the marketing site. The consent
@@ -46,24 +56,18 @@ export function buildConsentCookie(value: string, hostname: string, protocol: st
  * hand-edited cookie, a value left by some other tool on the shared domain - is
  * treated as "not decided yet" rather than propagated across `.vocdoni.io`.
  */
-function normalizeConsent(value: string | null): string | null {
+function normalizeConsent(value: string | null): ConsentValue | null {
   return value === CONSENT_ACCEPTED || value === CONSENT_REJECTED ? value : null
 }
 
-export function readConsentCookie(cookie: string | undefined): string | null {
-  if (!cookie) return null
-
-  for (const entry of cookie.split(';')) {
-    const separator = entry.indexOf('=')
-    if (separator === -1) continue
-    if (entry.slice(0, separator).trim() !== CONSENT_KEY) continue
-    try {
-      return decodeURIComponent(entry.slice(separator + 1).trim()) || null
-    } catch {
-      // A malformed percent-escape must not throw: consent is read while
-      // rendering, so an unhandled URIError would take the app down.
-      return null
-    }
+export function readConsentCookie(cookie: string | undefined): ConsentValue | null {
+  // Duplicate names are possible: a junk host-only cookie on this subdomain
+  // would coexist with the real `Domain=.vocdoni.io` one, in an order we don't
+  // control, and a `Domain=` write can never replace a host-only cookie. So
+  // return the first *recognised* decision rather than the first entry.
+  for (const value of readCookieValues(cookie, CONSENT_KEY)) {
+    const consent = normalizeConsent(value)
+    if (consent) return consent
   }
   return null
 }
@@ -87,8 +91,20 @@ function readLegacyConsent(): string | null {
 function mirrorConsent(value: string): void {
   try {
     if (localStorage.getItem(CONSENT_KEY) !== value) localStorage.setItem(CONSENT_KEY, value)
+    // Mark the mirror as cookie-era, so a later cookie deletion/expiry is
+    // honoured as a withdrawal instead of resurrecting this value.
+    if (localStorage.getItem(CONSENT_MIGRATED_KEY) === null) localStorage.setItem(CONSENT_MIGRATED_KEY, '1')
   } catch {
     // The cookie is the source of truth; losing the mirror is harmless.
+  }
+}
+
+function hasMigratedConsent(): boolean {
+  try {
+    return localStorage.getItem(CONSENT_MIGRATED_KEY) !== null
+  } catch {
+    // If storage is unreadable the mirror is too, so the question is moot.
+    return false
   }
 }
 
@@ -101,10 +117,10 @@ function writeConsent(value: string): void {
  * Get the current cookie consent status
  * @returns 'accepted', 'rejected', or null if no choice has been made
  */
-export function getCookieConsent(): string | null {
+export function getCookieConsent(): ConsentValue | null {
   if (typeof window === 'undefined') return null
 
-  const fromCookie = normalizeConsent(readConsentCookie(document.cookie))
+  const fromCookie = readConsentCookie(document.cookie)
   if (fromCookie) {
     // The choice may have been changed on the other site, which can only write
     // the shared cookie - this origin's mirror would otherwise stay stale, and
@@ -113,10 +129,17 @@ export function getCookieConsent(): string | null {
     return fromCookie
   }
 
+  const legacy = normalizeConsent(readLegacyConsent())
+  if (!legacy) return null
+
+  // A cookie-era mirror with the cookie gone means it expired or was removed
+  // (clearing cookies is a legitimate withdrawal); re-ask instead of silently
+  // re-minting a domain-wide cookie the visitor may have revoked.
+  if (hasMigratedConsent()) return null
+
   // Choices made before the shared cookie existed live in localStorage. Honour
   // one once and promote it, so nobody who already decided is asked again.
-  const legacy = normalizeConsent(readLegacyConsent())
-  if (legacy) writeConsent(legacy)
+  writeConsent(legacy)
   return legacy
 }
 
@@ -131,13 +154,45 @@ export function setCookieConsent(accepted: boolean): void {
 }
 
 /**
+ * The shared cookie has a second writer - vocdoni.io - and nothing in this
+ * document fires when that site changes the choice. Re-read whenever the tab
+ * regains focus/visibility and dispatch the regular change event when the
+ * decision differs, so consumers (analytics, chat) honour a cross-site
+ * revocation without waiting for a full reload.
+ * @returns a cleanup function removing the listeners
+ */
+export function watchCrossSiteConsent(): () => void {
+  if (typeof window === 'undefined') return () => {}
+
+  let known = getCookieConsent()
+  const remember = () => {
+    known = getCookieConsent()
+  }
+  const recheck = () => {
+    const current = getCookieConsent()
+    if (current === known) return
+    known = current
+    window.dispatchEvent(new Event(COOKIE_CONSENT_CHANGE_EVENT))
+  }
+
+  // Keep `known` in step with this origin's own writes, so a local decision
+  // doesn't produce a spurious change event on the next refocus.
+  window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, remember)
+  window.addEventListener('focus', recheck)
+  document.addEventListener('visibilitychange', recheck)
+  return () => {
+    window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, remember)
+    window.removeEventListener('focus', recheck)
+    document.removeEventListener('visibilitychange', recheck)
+  }
+}
+
+/**
  * Check if the user has made a cookie consent choice
  * @returns true if user has accepted or rejected, false if no choice made
  */
 export function hasCookieConsent(): boolean {
-  if (typeof window === 'undefined') return false
-  const consent = getCookieConsent()
-  return consent === CONSENT_ACCEPTED || consent === CONSENT_REJECTED
+  return getCookieConsent() !== null
 }
 
 export function hasAcceptedCookieConsent(): boolean {

--- a/src/components/Cookies/utils.ts
+++ b/src/components/Cookies/utils.ts
@@ -41,6 +41,15 @@ export function buildConsentCookie(value: string, hostname: string, protocol: st
   ].join('; ')
 }
 
+/**
+ * Only the two values this app writes count as a decision. Anything else - a
+ * hand-edited cookie, a value left by some other tool on the shared domain - is
+ * treated as "not decided yet" rather than propagated across `.vocdoni.io`.
+ */
+function normalizeConsent(value: string | null): string | null {
+  return value === CONSENT_ACCEPTED || value === CONSENT_REJECTED ? value : null
+}
+
 export function readConsentCookie(cookie: string | undefined): string | null {
   if (!cookie) return null
 
@@ -48,7 +57,13 @@ export function readConsentCookie(cookie: string | undefined): string | null {
     const separator = entry.indexOf('=')
     if (separator === -1) continue
     if (entry.slice(0, separator).trim() !== CONSENT_KEY) continue
-    return decodeURIComponent(entry.slice(separator + 1).trim()) || null
+    try {
+      return decodeURIComponent(entry.slice(separator + 1).trim()) || null
+    } catch {
+      // A malformed percent-escape must not throw: consent is read while
+      // rendering, so an unhandled URIError would take the app down.
+      return null
+    }
   }
   return null
 }
@@ -80,12 +95,12 @@ function writeConsent(value: string): void {
 export function getCookieConsent(): string | null {
   if (typeof window === 'undefined') return null
 
-  const fromCookie = readConsentCookie(document.cookie)
+  const fromCookie = normalizeConsent(readConsentCookie(document.cookie))
   if (fromCookie) return fromCookie
 
   // Choices made before the shared cookie existed live in localStorage. Honour
   // one once and promote it, so nobody who already decided is asked again.
-  const legacy = readLegacyConsent()
+  const legacy = normalizeConsent(readLegacyConsent())
   if (legacy) writeConsent(legacy)
   return legacy
 }

--- a/src/components/Cookies/utils.ts
+++ b/src/components/Cookies/utils.ts
@@ -77,15 +77,24 @@ function readLegacyConsent(): string | null {
   }
 }
 
+/**
+ * Mirrored, never read first: keeps a rollback of either site working, since
+ * the previous implementation only ever looked at localStorage.
+ *
+ * The write is conditional because consent is read while rendering, so this
+ * runs far more often than the choice actually changes.
+ */
+function mirrorConsent(value: string): void {
+  try {
+    if (localStorage.getItem(CONSENT_KEY) !== value) localStorage.setItem(CONSENT_KEY, value)
+  } catch {
+    // The cookie is the source of truth; losing the mirror is harmless.
+  }
+}
+
 function writeConsent(value: string): void {
   document.cookie = buildConsentCookie(value, window.location.hostname, window.location.protocol)
-  try {
-    // Mirrored, not read first: keeps a rollback of either site working, since
-    // the previous implementation only ever looked at localStorage.
-    localStorage.setItem(CONSENT_KEY, value)
-  } catch {
-    // The cookie above is the source of truth; losing the mirror is harmless.
-  }
+  mirrorConsent(value)
 }
 
 /**
@@ -96,7 +105,13 @@ export function getCookieConsent(): string | null {
   if (typeof window === 'undefined') return null
 
   const fromCookie = normalizeConsent(readConsentCookie(document.cookie))
-  if (fromCookie) return fromCookie
+  if (fromCookie) {
+    // The choice may have been changed on the other site, which can only write
+    // the shared cookie - this origin's mirror would otherwise stay stale, and
+    // a rollback here would then reinstate a decision the visitor has revoked.
+    mirrorConsent(fromCookie)
+    return fromCookie
+  }
 
   // Choices made before the shared cookie existed live in localStorage. Honour
   // one once and promote it, so nobody who already decided is asked again.

--- a/src/i18n/public-language.ts
+++ b/src/i18n/public-language.ts
@@ -1,3 +1,5 @@
+import { readCookie } from '~utils/cookies'
+
 export const PUBLIC_LANGUAGE_STORAGE_KEY = 'i18nextLng'
 export const PUBLIC_LANGUAGE_COOKIE_KEY = 'vocdoni-public-language'
 const PUBLIC_LANGUAGE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365
@@ -50,19 +52,6 @@ export const persistPublicLanguage = (
   return normalizedLanguage
 }
 
-const readCookieValue = (cookie: string | undefined, key: string) => {
-  if (!cookie) return null
-
-  const entry = cookie
-    .split(';')
-    .map((segment) => segment.trim())
-    .find((segment) => segment.startsWith(`${key}=`))
-
-  if (!entry) return null
-
-  return decodeURIComponent(entry.slice(key.length + 1))
-}
-
 const buildPublicLanguageCookie = ({ language, secure }: { language: string; secure: boolean }) =>
   `${PUBLIC_LANGUAGE_COOKIE_KEY}=${encodeURIComponent(language)}; Max-Age=${PUBLIC_LANGUAGE_COOKIE_MAX_AGE}; Path=/; SameSite=Lax${secure ? '; Secure' : ''}`
 
@@ -76,7 +65,7 @@ export const getPublicLanguageFromCookie = ({
   supportedLanguages: string[]
   cookie?: string
 }) => {
-  const cookieLanguage = readCookieValue(cookie, PUBLIC_LANGUAGE_COOKIE_KEY)
+  const cookieLanguage = readCookie(cookie, PUBLIC_LANGUAGE_COOKIE_KEY)
 
   return cookieLanguage ? normalizePublicLanguageCandidate(cookieLanguage, supportedLanguages) : null
 }

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -328,6 +328,16 @@ describe('posthog initialization', () => {
     await vi.waitFor(() => expect(mockPosthog.register).toHaveBeenCalledWith({ client: 'client-1' }))
   })
 
+  // `site` separates this app's events from vocdoni.io's in the shared PostHog
+  // project; registering it at init (not in a React effect) means no init path
+  // — including a retry after a failed chunk load — can miss it.
+  it('registers the site marker at init', async () => {
+    const { initializePosthog } = await import('./analytics')
+
+    initializePosthog({ key: 'phc_test', consent: null })
+    await vi.waitFor(() => expect(mockPosthog.register).toHaveBeenCalledWith({ site: 'app' }))
+  })
+
   it('does not initialize without a key or when consent was rejected', async () => {
     const { initializePosthog } = await import('./analytics')
 
@@ -385,26 +395,6 @@ describe('posthog initialization', () => {
 
     await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalledTimes(2))
     consoleSpy.mockRestore()
-  })
-})
-
-describe('toPosthogConsent', () => {
-  it('keeps the two explicit choices', async () => {
-    const { toPosthogConsent } = await import('./analytics')
-
-    expect(toPosthogConsent('accepted')).toBe('accepted')
-    expect(toPosthogConsent('rejected')).toBe('rejected')
-  })
-
-  // The value comes from localStorage, so it may be absent or hand-edited.
-  it('treats anything else as no decision', async () => {
-    const { toPosthogConsent } = await import('./analytics')
-
-    expect(toPosthogConsent(null)).toBeNull()
-    expect(toPosthogConsent(undefined)).toBeNull()
-    expect(toPosthogConsent('true')).toBeNull()
-    expect(toPosthogConsent('Accepted')).toBeNull()
-    expect(toPosthogConsent('')).toBeNull()
   })
 })
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -166,12 +166,6 @@ export const trackAnalyticsEvent = (event: AnalyticsEvent): void => {
 
 export type PosthogConsent = 'accepted' | 'rejected' | null
 
-// The consent choice lives in localStorage, so it is user-editable and may hold
-// anything. Anything that is not an explicit choice is treated as "no decision
-// yet" (cookieless, anonymous) rather than being trusted as one.
-export const toPosthogConsent = (value: string | null | undefined): PosthogConsent =>
-  value === 'accepted' || value === 'rejected' ? value : null
-
 type PosthogInitConfig = {
   key: string
   host?: string
@@ -303,6 +297,11 @@ export const initializePosthog = ({ key, host, analyticsClientId, consent }: Pos
         capture_exceptions: true,
         before_send: posthogBeforeSend,
       })
+      // `site` separates this app's events from vocdoni.io's in the shared
+      // PostHog project. Registered here, not in a React effect, so it lands
+      // on every init path - including a retry after a failed chunk load,
+      // which no effect re-runs for.
+      posthog.register({ site: 'app' })
       if (analyticsClientId) {
         posthog.register({ client: analyticsClientId })
       }

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure cookie-string helpers shared by every module that parses cookies
+ * (consent, public language). String-in/string-out on purpose: SSR code paths
+ * receive the Cookie header as a plain string, and keeping `document` out of
+ * here lets both sides use the same parser.
+ */
+
+/**
+ * All decoded values for `key`, in the order the browser serialised them.
+ * Duplicate names are possible (a host-only cookie can coexist with a
+ * `Domain=` one, and the serialisation order is not under our control), so
+ * callers that validate values should scan the list rather than trust the
+ * first entry. Malformed percent-escapes are skipped instead of throwing:
+ * cookies are read while rendering, so an unhandled URIError would take the
+ * app down.
+ */
+export function readCookieValues(cookie: string | undefined, key: string): string[] {
+  if (!cookie) return []
+
+  const values: string[] = []
+  for (const entry of cookie.split(';')) {
+    const separator = entry.indexOf('=')
+    if (separator === -1) continue
+    if (entry.slice(0, separator).trim() !== key) continue
+    try {
+      values.push(decodeURIComponent(entry.slice(separator + 1).trim()))
+    } catch {
+      // Skip the malformed entry; a valid duplicate may follow.
+    }
+  }
+  return values
+}
+
+/**
+ * First value for `key`, or null when the cookie is absent or empty.
+ */
+export function readCookie(cookie: string | undefined, key: string): string | null {
+  return readCookieValues(cookie, key)[0] || null
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -66,6 +66,13 @@ if (!i18n.isInitialized) {
 // Cleanup after each test
 afterEach(async () => {
   cleanup()
+  // jsdom keeps `document.cookie` for the whole file. The cookie consent choice
+  // now lives in a cookie (shared with vocdoni.io), so without this a decision
+  // made in one test leaks into the next.
+  for (const entry of document.cookie.split(';')) {
+    const name = entry.split('=')[0].trim()
+    if (name) document.cookie = `${name}=; Path=/; Max-Age=0`
+  }
   const { resetReactProvidersMock, resetAuthMock } = await import('./src/test-utils-react-providers-mock')
   resetReactProvidersMock()
   resetAuthMock()

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -73,6 +73,11 @@ afterEach(async () => {
     const name = entry.split('=')[0].trim()
     if (name) document.cookie = `${name}=; Path=/; Max-Age=0`
   }
+  // Clearing the cookie is not enough: setCookieConsent also mirrors the choice
+  // into localStorage, and getCookieConsent would promote that mirror straight
+  // back into a fresh cookie in the next test.
+  localStorage.removeItem('vocdoni-cookie-consent')
+  localStorage.removeItem('vocdoni-cookie-consent-migrated')
   const { resetReactProvidersMock, resetAuthMock } = await import('./src/test-utils-react-providers-mock')
   resetReactProvidersMock()
   resetAuthMock()


### PR DESCRIPTION
The app half of running `vocdoni.io` and `app.vocdoni.io` in **one** PostHog project, so a funnel can start on a marketing landing page and end at a paid subscription.

Pairs with vocdoni/vocdoni.io#150. **Both must ship** — either alone leaves the bridge half-built.

## Why one project

The free plan allows exactly one project, and PostHog cannot query across projects. "Cross-project funnels" do not exist as a feature on any tier, so one project with two sources is the only shape that works — and it is the one we want anyway. Both sites ship the same `phc_` key.

Region verified: the project token is **EU Cloud** (`eu.i.posthog.com` returns 200, `us.i.posthog.com` returns 401).

## The identity bridge, and the blocker it removes

posthog-js writes its persistence cookie with `cross_subdomain_cookie`, which defaults to `true` for `vocdoni.io` (only `herokuapp.com`, `vercel.app` and `netlify.app` are excluded). The cookie name derives from the project token, and both sites use the same token, so they read and write the same cookie — and `distinct_id` is one of the keys always mirrored into it.

That only works while **both** sites run with cookie persistence, which only happens once consent is known. Consent lived in `localStorage`, which is scoped per origin. A visitor who accepted on `vocdoni.io` therefore arrived here as "no decision yet": memory persistence, shared cookie ignored, fresh anonymous id minted — and every website → app funnel silently reporting near-zero.

So the consent choice moves to a cookie scoped to `.vocdoni.io`. A pre-existing `localStorage` value is honoured once and promoted, so nobody who already decided is asked again, and it stays mirrored there to keep a rollback of either site working. Local, staging and preview hosts get a host-only cookie and never join production identities.

`identify()` on signup then merges the shared anonymous id into the person, so marketing pageviews from before the account existed land in the same person's timeline.

## Commits

1. **`feat(consent)`** — the shared `.vocdoni.io` consent cookie, with migration. Cookies are now cleared between tests: jsdom keeps `document.cookie` for a whole file, so a decision made in one test was leaking into the next.
2. **`feat(analytics)`** — registers `site: 'app'`. More durable than `$host` across preview hosts and custom domains. Documents the cross-site contract in `docs/analytics.md`.
3. **`feat(analytics)`** — a **Vocdoni · Web → app** dashboard in the insights script: acquisition (pageview → CTA → signup → org → first election), which vertical converts, blog and learn → signup, Cal.com sales assist, marketing-sourced revenue, activation by locale, first-touch revenue attribution, event volume by `site`, CTA clicks by `page_type`.

Two details in that last one:

- Every funnel stays **person-level**. The existing app funnels aggregate by the `organization` group, which is right for them, but a website visitor has no org yet — group aggregation would drop step one and make the funnel look broken rather than empty.
- Campaign breakdowns read `$initial_utm_source` as a **person** property. Because the anonymous id is minted on the marketing site, that records the website's first touch rather than whichever app URL the visitor landed on.

## Before merging

- `POSTHOG_KEY` must be set on the vocdoni.io side for any of this to produce data. Until it is, that site ships with PostHog fully inert.
- PostHog needs naming in the privacy policy (that copy lives in the vocdoni.io repo; a draft is with the DPO).
- **Do not run `pnpm posthog:insights` yet** — breakdowns against an empty project resolve to nothing and read as a broken dashboard. Run it once real cross-site traffic has landed.

## Testing

- `npx vitest run` — 746 passed, 0 failed
- `npx tsc --noEmit` — clean
- `node scripts/posthog-insights.mjs --dry-run` — all insights build valid query JSON

> Note: this branch does not carry the `public-page-redirect.test.tsx` fix from #1752, so CI here may trip on that pre-existing flake until #1752 merges and this rebases.
