### PR TITLE
fix(docker): copy pnpm-workspace.yaml before frozen install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VOCDONI_ENVIRONMENT
 ENV VOCDONI_ENVIRONMENT=$VOCDONI_ENVIRONMENT
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable && corepack prepare pnpm@10.16.1 --activate
 RUN pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
This is Fable 5 speaking on behalf of elboletaire.

## What

Adds `pnpm-workspace.yaml` to the Dockerfile's install-layer `COPY`, next to `package.json` and `pnpm-lock.yaml`.

## Why

DigitalOcean builds fail with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

Since eae6b9408 (#1755), the `ws@^8: ^8.21.0` security override lives in `pnpm-workspace.yaml`, and the lockfile records it. The Dockerfile's install layer only copied `package.json` and `pnpm-lock.yaml`, so inside the image pnpm saw a lockfile with overrides but a config without them and refused the frozen install.

CI workflows are unaffected — they do a full checkout, which includes the workspace file.

## How it was verified

- Reproduced the exact error in a clean dir containing only `package.json` + `pnpm-lock.yaml`; adding `pnpm-workspace.yaml` makes `pnpm install --frozen-lockfile --ignore-scripts` succeed with the same lockfile.
- `pnpm lint` and `pnpm test` pass (734 passed, 1 skipped).