### PR TITLE
chore(deps): resolve decode-uri-component dependabot alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   ws@^8: ^8.21.0
+  decode-uri-component@<0.5.0: ^0.5.0
 
 importers:
 
@@ -3668,9 +3669,9 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
-  decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
-    engines: {node: '>=0.10'}
+  decode-uri-component@0.5.0:
+    resolution: {integrity: sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==}
+    engines: {node: '>=14.16'}
 
   dedent@1.7.1:
     resolution: {integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==}
@@ -8058,7 +8059,7 @@ snapshots:
   '@metamask/json-rpc-engine@8.0.2':
     dependencies:
       '@metamask/rpc-errors': 6.4.0
-      '@metamask/safe-event-emitter': 3.1.2
+      '@metamask/safe-event-emitter': 3.1.3
       '@metamask/utils': 8.5.0
     transitivePeerDependencies:
       - supports-color
@@ -8066,7 +8067,7 @@ snapshots:
   '@metamask/json-rpc-middleware-stream@7.0.2':
     dependencies:
       '@metamask/json-rpc-engine': 8.0.2
-      '@metamask/safe-event-emitter': 3.1.2
+      '@metamask/safe-event-emitter': 3.1.3
       '@metamask/utils': 8.5.0
       readable-stream: 3.6.2
     transitivePeerDependencies:
@@ -8204,10 +8205,10 @@ snapshots:
       '@metamask/superstruct': 3.2.1
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
-      '@types/debug': 4.1.12
-      debug: 4.3.4
+      '@types/debug': 4.1.13
+      debug: 4.4.3
       pony-cause: 2.1.11
-      semver: 7.7.3
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8218,10 +8219,10 @@ snapshots:
       '@metamask/superstruct': 3.2.1
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
-      '@types/debug': 4.1.12
-      debug: 4.3.4
+      '@types/debug': 4.1.13
+      debug: 4.4.3
       pony-cause: 2.1.11
-      semver: 7.7.3
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -11737,7 +11738,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decode-uri-component@0.2.2: {}
+  decode-uri-component@0.5.0: {}
 
   dedent@1.7.1(babel-plugin-macros@3.1.0):
     optionalDependencies:
@@ -13826,7 +13827,7 @@ snapshots:
 
   query-string@7.1.3:
     dependencies:
-      decode-uri-component: 0.2.2
+      decode-uri-component: 0.5.0
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,11 @@ overrides:
   # will never bump), viem pins 8.18.3 exact, engine.io-client allows only
   # ~8.18.3 — all below the 8.21.0 security fix (GHSA alerts #181/#211).
   'ws@^8': ^8.21.0
+  # query-string 7.1.3 (declared by @walletconnect/utils 2.21.x) pins
+  # decode-uri-component ^0.2.2, below the 0.5.0 DoS fix (GHSA-vcc3-ghjq-m6fr,
+  # alert #252). 0.5.0 is ESM-only, which would break query-string's CJS
+  # `require()` — but a full node_modules sweep shows nothing ever imports
+  # query-string at runtime (walletconnect declares it without using it, and
+  # dropped it in 2.24.0), so the jump is safe. Drop this once the
+  # wagmi/rainbowkit stack pulls @walletconnect/* >= 2.24.
+  'decode-uri-component@<0.5.0': ^0.5.0


### PR DESCRIPTION
This is Fable 5 speaking on behalf of elboletaire.

## What

Resolves the only open Dependabot security alert, [#252](https://github.com/vocdoni/ui-scaffold/security/dependabot/252) (GHSA-vcc3-ghjq-m6fr, medium): DoS via exponential decoding of malformed percent-encoded input in `decode-uri-component` <= 0.4.2, patched in 0.5.0.

Adds a `pnpm-workspace.yaml` override (`'decode-uri-component@<0.5.0': ^0.5.0`), following the same policy as the existing `ws` override — the file's own comments prescribe overrides exactly when a dependent pins a vulnerable range.

## Why an override

The vulnerable 0.2.2 is pulled in solely by `query-string@7.1.3` (declared by `@walletconnect/utils` 2.21.x), which pins `^0.2.2` — no lockfile refresh can reach 0.5.0. Upgrading the WalletConnect stack to >= 2.24 (which dropped query-string entirely) would be the real fix, but that's driven by wagmi/rainbowkit pins and out of scope for a medium DoS alert.

## The ESM catch (verified)

`decode-uri-component@0.5.0` is **ESM-only** with a default export, and I verified empirically that query-string's CJS `require()` of it breaks (`decodeComponent is not a function`). This is safe anyway: a full sweep of every `.js`/`.cjs`/`.mjs` under `node_modules/.pnpm` shows **nothing imports query-string at runtime** — `@walletconnect/utils` declares the dependency but never references it in any of its bundles (and removed it upstream in 2.24.0). The override comment documents this and says to drop it once the stack reaches `@walletconnect/* >= 2.24`.

The lockfile re-resolve also picked up a few in-range transitive refreshes (`debug` 4.3.4→4.4.3, `semver` 7.7.3→7.8.5, `@metamask/safe-event-emitter` 3.1.2→3.1.3, `@types/debug`).

## Verification

- `pnpm lint` clean (tsc + prettier)
- `pnpm test`: 734 passed, 1 skipped
- Lockfile resolves `decode-uri-component@0.5.0` everywhere; 0.2.2 gone (closes the alert)
- Residual risk: the "nothing uses query-string" claim rests on a static grep of installed bundles; a manual WalletConnect connect test before merging would close it completely.