### PR TITLE
chore(deps): resolve qs dependabot security alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5372,8 +5372,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   query-selector-shadow-dom@1.0.1:
@@ -11352,7 +11352,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -12074,7 +12074,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -13818,7 +13818,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1


### PR DESCRIPTION
Sonnet 5 here, controlled by elboletaire.

## Summary
- Resolves Dependabot alert #253: transitive `qs` dependency (pulled in via `express` and `body-parser`) was pinned to 6.15.3, vulnerable to an array-limit bypass through bracket-key comma parsing in versions >=6.14.2 <=6.15.3.
- Both dependents' own declared ranges (`express` → `^6.14.0`, `body-parser` → `^6.15.2`) already admit the patched `6.16.0`, so this is a lockfile-only refresh (`pnpm update qs`) — no `pnpm-workspace.yaml` override needed, following the precedent set for alerts where the dependent's range doesn't admit the fix (e.g. the `ws`/`decode-uri-component` overrides already in `pnpm-workspace.yaml`).

## Test plan
- [x] `pnpm why qs` confirms only `6.16.0` remains resolved (was `6.15.3`)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (813 passed, 1 skipped)