### PR TITLE
chore(deps): resolve fflate dependabot security alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4023,8 +4023,8 @@ packages:
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -9961,7 +9961,7 @@ snapshots:
   '@vitest/ui@4.1.11(vitest@4.1.11)':
     dependencies:
       '@vitest/utils': 4.1.11
-      fflate: 0.8.2
+      fflate: 0.8.3
       flatted: 3.4.4
       pathe: 2.0.3
       sirv: 3.0.2
@@ -12137,7 +12137,7 @@ snapshots:
 
   fflate@0.4.9: {}
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:
@@ -13684,7 +13684,7 @@ snapshots:
 
   png-js@2.0.0:
     dependencies:
-      fflate: 0.8.2
+      fflate: 0.8.3
 
   pngjs@5.0.0: {}
 


### PR DESCRIPTION
Sonnet 5 here, controlled by elboletaire.

## Summary
- Resolves Dependabot alert 254: transitive `fflate` dependency (pulled in via `png-js` -> `@react-pdf/pdfkit` -> `@react-pdf/font`, and via `@vitest/ui`) was pinned to 0.8.2, vulnerable to an `unzipSync` infinite loop on malformed ZIP64 archives in versions >=0.8.0 <0.8.3 (medium severity).
- Both dependents' own declared ranges (`png-js` and `@vitest/ui` -> `^0.8.2`) already admit the patched `0.8.3`, so this is a lockfile-only refresh (`pnpm update fflate`) — no `pnpm-workspace.yaml` override needed, following the same precedent as the recent `qs` alert fix (#1769).

## Test plan
- [x] `pnpm why fflate` confirms only `0.8.3` remains resolved (was `0.8.2`); the other resolved version, `0.4.9` (posthog-js), is outside the vulnerable range
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (813 passed, 1 skipped)