### PR TITLE
test(e2e): cover the weighted + question-matrix voting journey

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -78,10 +78,11 @@ because the failing request is made by the page.
 
 ## What it covers
 
-| Spec                    | Journey                                                                                                                                                                                                                                                                                                                                   |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `signup-otp.e2e.ts`     | Register → read the verification code out of the emailed message (and check its link points back at this app) → verify → create an organization → land in `/admin`. Plus the negative case: a wrong code is rejected.                                                                                                                     |
-| `csp-2fa-voting.e2e.ts` | The whole organizer→voter chain: signup → organization → CSV memberbase import → create a process with `memberNumber` credentials and an **email 2FA** census → publish on-chain → then, in a separate browser context, identify as a voter, receive the OTP, submit it and cast a ballot. Plus: a non-member gets no OTP mailed to them. |
+| Spec                              | Journey                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `signup-otp.e2e.ts`               | Register → read the verification code out of the emailed message (and check its link points back at this app) → verify → create an organization → land in `/admin`. Plus the negative case: a wrong code is rejected.                                                                                                                                                                    |
+| `csp-2fa-voting.e2e.ts`           | The whole organizer→voter chain: signup → organization → CSV memberbase import → create a process with `memberNumber` credentials and an **email 2FA** census → publish on-chain → then, in a separate browser context, identify as a voter, receive the OTP, submit it and cast a ballot. Plus: a non-member gets no OTP mailed to them.                                                |
+| `weighted-question-matrix.e2e.ts` | The manual QA "creating processes matrix", folded into one journey: a **weighted** census (memberbase weight column → voting power) and one process mixing single+extended, multi+plain and multi+extended questions — each question its own on-chain election, voted in one batch. Asserts the voter sees their weight and that public tallies count it (7, not 1) per selected choice. |
 
 Everything runs through the UI. Nothing is provisioned behind the app's back, so
 a break anywhere along that chain fails here.
@@ -93,7 +94,7 @@ a break anywhere along that chain fails here.
   sends.
 - `helpers/flows.ts` — reusable journeys (`registerAndVerify`,
   `createOrganization`, `importMembers`, `createAndPublishTwoFactorProcess`,
-  `authenticateVoterWithOtp`, `castVote`).
+  `authenticateVoterWithOtp`, `fillBallot`/`submitBallot`, `castVote`).
 - `helpers/fixtures.ts` — the `test` export to use instead of
   `@playwright/test` (it suppresses the cookie banner, which otherwise blocks
   clicks), plus helpers for Chakra's checkbox / switch / pin-input / combobox.

--- a/e2e/csp-2fa-voting.e2e.ts
+++ b/e2e/csp-2fa-voting.e2e.ts
@@ -31,8 +31,7 @@ test.describe('voting with a CSP + email 2FA census', () => {
 
     const processId = await createAndPublishTwoFactorProcess(page, {
       title: `E2E vote ${seed}`,
-      question: 'Do you approve?',
-      choices: ['Yes', 'No'],
+      questions: [{ title: 'Do you approve?', choices: [{ label: 'Yes' }, { label: 'No' }] }],
     })
     expect(processId).toBeTruthy()
 
@@ -99,8 +98,7 @@ test.describe('voting with a CSP + email 2FA census', () => {
     await importMembers(page, members)
     const processId = await createAndPublishTwoFactorProcess(page, {
       title: `E2E guard ${seed}`,
-      question: 'Do you approve?',
-      choices: ['Yes', 'No'],
+      questions: [{ title: 'Do you approve?', choices: [{ label: 'Yes' }, { label: 'No' }] }],
     })
 
     const voterContext = await browser.newContext()

--- a/e2e/helpers/data.ts
+++ b/e2e/helpers/data.ts
@@ -20,6 +20,8 @@ export type TestMember = {
   surname: string
   email: string
   memberNumber: string
+  /** Voting power for weighted processes. Optional: omitted, the CSV has no weight column. */
+  weight?: number
 }
 
 /**
@@ -35,7 +37,7 @@ export type TestMember = {
  * `Date.now()`, which repeats roughly every 16 minutes. A repeat would leave a
  * previous run's OTP sitting in the inbox under the same address.
  */
-export const makeMembers = (count: number, seed: string): TestMember[] => {
+export const makeMembers = (count: number, seed: string, weights?: number[]): TestMember[] => {
   const runToken = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e6).toString(36)}`
 
   return Array.from({ length: count }, (_, index) => ({
@@ -43,12 +45,22 @@ export const makeMembers = (count: number, seed: string): TestMember[] => {
     surname: 'Test',
     email: `member-${runToken}-${index + 1}@test.local`,
     memberNumber: `${seed}${index + 1}`,
+    // Weighted processes reject a census whose members lack a voting power, so
+    // when weights are requested every member must get one.
+    ...(weights ? { weight: weights[index] } : {}),
   }))
 }
 
-/** The members as a CSV buffer, matching the importer's expected header names. */
+/**
+ * The members as a CSV buffer, matching the importer's expected header names.
+ * The weight column only exists when the members carry weights — the mapper in
+ * `importMembers` mirrors this, so both derive from the same data.
+ */
 export const membersCsv = (members: TestMember[]): Buffer => {
-  const header = 'name,surname,email,memberNumber'
-  const rows = members.map((m) => `${m.name},${m.surname},${m.email},${m.memberNumber}`)
+  const weighted = members.some((m) => m.weight !== undefined)
+  const header = `name,surname,email,memberNumber${weighted ? ',weight' : ''}`
+  const rows = members.map(
+    (m) => `${m.name},${m.surname},${m.email},${m.memberNumber}${weighted ? `,${m.weight}` : ''}`
+  )
   return Buffer.from([header, ...rows].join('\n'), 'utf8')
 }

--- a/e2e/helpers/flows.ts
+++ b/e2e/helpers/flows.ts
@@ -103,8 +103,11 @@ export const importMembers = async (page: Page, members: TestMember[]): Promise<
 
   // The mapper starts empty — nothing is auto-detected — so every column the
   // census will need must be mapped explicitly. The option labels are the CSV's
-  // own header names.
-  for (const column of ['name', 'surname', 'email', 'memberNumber']) {
+  // own header names. `weight` (the voting power a weighted process reads) only
+  // exists when the members carry one, matching what `membersCsv` emitted.
+  const columns = ['name', 'surname', 'email', 'memberNumber']
+  if (members.some((member) => member.weight !== undefined)) columns.push('weight')
+  for (const column of columns) {
     await selectComboboxOption(page, page.locator(`#${column}`), column)
   }
 
@@ -116,10 +119,69 @@ export const importMembers = async (page: Page, members: TestMember[]): Promise<
   await expect(page.getByText(first.email, { exact: false })).toBeVisible({ timeout: 120_000 })
 }
 
+export type ChoiceSpec = {
+  label: string
+  /** Filled through the extended-info editor; requires `extendedInfo` on the question. */
+  description?: string
+}
+
+/**
+ * One wizard question. Type and presentation are per-question settings — every
+ * question is published as its own on-chain election, which is exactly what
+ * lets one process cover the whole single/multi × plain/extended matrix.
+ */
+export type QuestionSpec = {
+  title: string
+  /** The wizard default is single choice. */
+  type?: 'single' | 'multiple'
+  /** Switches the question to extended choice cards (per-choice description/image). */
+  extendedInfo?: boolean
+  /** Exactly two: the wizard starts every question with two empty options. */
+  choices: [ChoiceSpec, ChoiceSpec]
+}
+
 export type ProcessSpec = {
   title: string
-  question: string
-  choices: [string, string]
+  questions: QuestionSpec[]
+  /** Weighted by the memberbase voting-power column ("One person, one vote" otherwise). */
+  weighted?: boolean
+}
+
+/**
+ * Fills one question card of the create wizard. Field names come from
+ * react-hook-form (`questions.N....`), so nothing here depends on translated
+ * copy except the question-type option labels, which the Select renders from
+ * i18n defaults.
+ */
+const fillQuestion = async (page: Page, index: number, question: QuestionSpec): Promise<void> => {
+  await page.fill(`input[name="questions.${index}.title"]`, question.title)
+
+  if (question.type === 'multiple') {
+    // One type Select per question, in question order. It has no stable id —
+    // only its aria-label, which chakra-react-select puts on the focusable
+    // input.
+    await selectComboboxOption(page, page.getByLabel('Question type').nth(index), /Multiple choice/i)
+  }
+
+  if (question.extendedInfo) {
+    // Switch.Root's `id` prop becomes the zag machine id, and the DOM root
+    // renders as `switch:<id>` — hence the attribute selector instead of `#`.
+    const extendedSwitch = page.locator(`[id="switch:extended-info-${index}"]`)
+    await toggleSwitch(extendedSwitch)
+  }
+
+  for (const [optionIndex, choice] of question.choices.entries()) {
+    const optionInput = page.locator(`input[name="questions.${index}.options.${optionIndex}.option"]`)
+    await optionInput.fill(choice.label)
+
+    if (choice.description) {
+      // The per-choice description is a Lexical editor (a contenteditable), not
+      // an input, and only exists on extended cards. Scope it through the card
+      // that holds this option's title input.
+      const card = page.locator('[data-choice-card]').filter({ has: optionInput })
+      await card.locator('[contenteditable="true"]').fill(choice.description)
+    }
+  }
 }
 
 /**
@@ -156,19 +218,30 @@ export const createAndPublishTwoFactorProcess = async (page: Page, spec: Process
   await page.reload()
   await expect(page.locator('input[name="title"]')).toHaveValue(spec.title)
 
-  await page.fill('input[name="questions.0.title"]', spec.question)
-  await page.fill('input[name="questions.0.options.0.option"]', spec.choices[0])
-  await page.fill('input[name="questions.0.options.1.option"]', spec.choices[1])
+  for (const [index, question] of spec.questions.entries()) {
+    // The restored draft holds one default question; the rest are appended.
+    if (index > 0) {
+      await page.getByRole('button', { name: /Add question/i }).click()
+      await expect(page.locator(`input[name="questions.${index}.title"]`)).toBeVisible()
+    }
+    await fillQuestion(page, index, question)
+  }
 
-  // Guard the race above: if it ever changes shape, fail here with an obvious
-  // message instead of at the publish step's validation errors.
-  await expect(page.locator('input[name="questions.0.title"]')).toHaveValue(spec.question)
+  // Guard the draft race above: if it ever changes shape, fail here with an
+  // obvious message instead of at the publish step's validation errors.
+  await expect(page.locator('input[name="questions.0.title"]')).toHaveValue(spec.questions[0].title)
 
   // Live results, not the "hidden until the end" default: a secret process
   // seals ballots with per-question encryption keys the keykeepers only publish
   // after publication, which is a different feature with its own timing. This
   // suite is about the email/OTP journey, so keep the ballot path plain.
   await selectComboboxOption(page, page.locator('#resultVisibility'), /Live results/i)
+
+  if (spec.weighted) {
+    // Votes weighted by the memberbase voting-power column — the members must
+    // have been imported with weights or the census validation below rejects.
+    await selectComboboxOption(page, page.locator('#weightedVote'), /Weighted by voting power/i)
+  }
 
   // The census is the group; voter authentication cannot be configured until
   // one is chosen (the modal button reports as much).
@@ -285,25 +358,75 @@ export const authenticateVoterWithOtp = async (page: Page, member: TestMember): 
 }
 
 /**
- * Casts a vote for the choice at `choiceIndex` on the (single) question and
- * waits for the process to record it.
- *
- * The choice radios carry the ballot value as their `value` ("0", "1", …), so
- * the selection does not depend on the option's label. The confirm button does
- * — it is rendered by `@vocdoni/react-components`, outside this repo, so there
- * is no test-id to add to it.
+ * One question's selections on the voting form. `choices` holds ballot values
+ * ("0", "1", … as rendered on the inputs), so nothing depends on option labels.
  */
-export const castVote = async (page: Page, choiceIndex: number): Promise<void> => {
-  await page.locator(`input[type="radio"][value="${choiceIndex}"]`).check({ force: true })
+export type BallotSelection = {
+  /** Question position in the form — matches the wizard's question order. */
+  question: number
+  /** Must match the published question type: it decides radio vs checkbox. */
+  type: 'single' | 'multiple'
+  choices: number[]
+}
 
+/**
+ * The container of the question at `index` on the voting form. The form id is
+ * `election-questions-<processId>` but a prefix match is enough — one process
+ * renders one questions form — and its direct children are the question cards
+ * in process order (the "voted" notice only mounts after voting).
+ */
+const questionContainer = (page: Page, index: number): Locator =>
+  page.locator('form[id^="election-questions-"] > div').nth(index)
+
+/**
+ * Fills ballot selections across the questions form.
+ *
+ * Single-choice questions render hidden radios carrying the ballot value, so
+ * they need `check({ force })` (the visible control intercepts the click).
+ * Multiple-choice questions render Chakra checkboxes whose parts carry
+ * deterministic ids (`question-<q>-choice-<value>-control`) — the visible
+ * control is the click target there.
+ */
+export const fillBallot = async (page: Page, selections: BallotSelection[]): Promise<void> => {
+  for (const selection of selections) {
+    const container = questionContainer(page, selection.question)
+    for (const value of selection.choices) {
+      if (selection.type === 'single') {
+        await container.locator(`input[type="radio"][value="${value}"]`).check({ force: true })
+      } else {
+        await container.locator(`[id="question-${selection.question}-choice-${value}-control"]`).click()
+      }
+    }
+  }
+}
+
+/**
+ * Submits the filled ballot and waits for the whole batch to be recorded.
+ *
+ * The confirm button is rendered by `@vocdoni/react-components`, outside this
+ * repo, so there is no test-id to add to it.
+ *
+ * Waits for the success modal, NOT for the Vote button to disappear: the button
+ * goes as soon as submission starts, so that would pass while the vote is still
+ * being relayed (and would keep passing if it then failed). The modal renders
+ * only once EVERY question of the process reports the voter as having voted —
+ * each question is its own on-chain election, so this is also the multi-question
+ * completion check.
+ */
+export const submitBallot = async (page: Page): Promise<void> => {
   await page.getByRole('button', { name: /^Vote$/ }).click()
 
   const confirmation = page.getByRole('dialog')
   await confirmation.getByRole('button', { name: /confirm/i }).click()
 
-  // Wait for the success modal, NOT for the Vote button to disappear: the
-  // button goes as soon as submission starts, so that would pass while the vote
-  // is still being relayed (and would keep passing if it then failed). The
-  // modal renders only once the process reports the voter as having voted.
   await expect(page.getByTestId('vote-success-modal')).toBeVisible({ timeout: 180_000 })
+}
+
+/**
+ * Casts a vote for the choice at `choiceIndex` on the (single) question and
+ * waits for the process to record it.
+ */
+export const castVote = async (page: Page, choiceIndex: number): Promise<void> => {
+  await fillBallot(page, [{ question: 0, type: 'single', choices: [choiceIndex] }])
+  await submitBallot(page)
 }

--- a/e2e/weighted-question-matrix.e2e.ts
+++ b/e2e/weighted-question-matrix.e2e.ts
@@ -1,0 +1,158 @@
+import { makeMembers } from './helpers/data'
+import {
+  authenticateVoterWithOtp,
+  createAndPublishTwoFactorProcess,
+  fillBallot,
+  importMembers,
+  signUpWithOrganization,
+  submitBallot,
+} from './helpers/flows'
+import { expect, prepareContext, test } from './helpers/fixtures'
+
+/**
+ * Flow 3 — the process-creation matrix from the manual QA procedure, folded
+ * into a single journey.
+ *
+ * The original checklist crossed census types (memberbase, spreadsheet, web3)
+ * with question types and presentations. Two of those axes no longer exist:
+ * the wizard only builds memberbase/CSP censuses now, and question type +
+ * extended info became per-question settings — every question publishes as its
+ * own on-chain election, so one process can carry the whole
+ * single/multi × plain/extended matrix at once.
+ *
+ * The non-weighted single-choice-plain corner is already covered by
+ * `csp-2fa-voting.e2e.ts`, so this spec takes the rest in one weighted
+ * process: single+extended, multi+plain and multi+extended questions, voted in
+ * one batch by a member whose voting power is 7. The weight is asserted at
+ * both ends — the voter sees it before voting, and the public results tally 7
+ * (not 1) per selected choice — which also proves the memberbase weight column
+ * actually reached the census.
+ */
+test.describe('weighted voting across the question matrix', () => {
+  test('a weighted member votes single/multi choice, plain and extended questions in one process', async ({
+    page,
+    browser,
+  }) => {
+    // Signup + import + 3-election publish + batched 3-envelope vote is the
+    // longest journey in the suite; the config's default 5 minutes is sized for
+    // single-election flows.
+    test.setTimeout(10 * 60_000)
+
+    const seed = String(Date.now()).slice(-6)
+    // Distinct weights so a tally of 7 can only mean "the first member's
+    // weight", never a coincidental sum of the others (3 + 1, or 1 + 1 + 1).
+    const members = makeMembers(3, seed, [7, 3, 1])
+    const organizationName = `Weighted Org ${seed}`
+
+    // --- organizer -------------------------------------------------------
+    await signUpWithOrganization(page, organizationName)
+    await importMembers(page, members)
+
+    const processId = await createAndPublishTwoFactorProcess(page, {
+      title: `E2E matrix ${seed}`,
+      weighted: true,
+      // Choice labels are unique across questions on purpose: the results
+      // assertions below locate tally rows by them.
+      questions: [
+        {
+          title: 'Board renewal',
+          extendedInfo: true,
+          choices: [
+            { label: 'Approve renewal', description: 'Extends the board mandate for two more years' },
+            { label: 'Reject renewal', description: 'Opens a new election for every seat' },
+          ],
+        },
+        {
+          title: 'Committee members',
+          type: 'multiple',
+          choices: [{ label: 'Alice Example' }, { label: 'Bob Example' }],
+        },
+        {
+          title: 'Budget projects',
+          type: 'multiple',
+          extendedInfo: true,
+          choices: [
+            { label: 'New park', description: 'Green area next to the river' },
+            { label: 'New library', description: 'Extension of the current building' },
+          ],
+        },
+      ],
+    })
+    expect(processId).toBeTruthy()
+
+    // --- voter -----------------------------------------------------------
+    const voterContext = await browser.newContext()
+    await prepareContext(voterContext)
+    const voter = await voterContext.newPage()
+
+    try {
+      const [member] = members // weight 7
+
+      await voter.goto(`/processes/${processId}`)
+      await expect(voter.getByRole('heading', { name: `E2E matrix ${seed}` }).first()).toBeVisible()
+
+      // Extended info made it through publish: the per-choice descriptions the
+      // wizard stored as metadata render on the public ballot.
+      await expect(voter.getByText('Extends the board mandate for two more years')).toBeVisible()
+      await expect(voter.getByText('Green area next to the river')).toBeVisible()
+
+      await authenticateVoterWithOtp(voter, member)
+
+      // The census weight reached the voter session: the weighted process
+      // shows the member's voting power next to the vote button.
+      const weightBadge = voter.getByText(/voting power/i).locator('..')
+      await expect(weightBadge).toBeVisible()
+      await expect(weightBadge).toContainText('7')
+
+      // Nobody has voted yet.
+      await expect(voter.getByTestId('process-vote-count')).toContainText('0')
+
+      // One ballot across all three questions — a single-choice pick, a
+      // full multi-choice selection, and a partial one — relayed as one batch.
+      await fillBallot(voter, [
+        { question: 0, type: 'single', choices: [1] }, // Reject renewal
+        { question: 1, type: 'multiple', choices: [0, 1] }, // Alice + Bob
+        { question: 2, type: 'multiple', choices: [0] }, // New park
+      ])
+      await submitBallot(voter)
+    } finally {
+      await voterContext.close()
+    }
+
+    // --- observer --------------------------------------------------------
+    // A fresh anonymous context (a voter's CSP session does not survive a
+    // reload): the ballots really reached the chain if the public page reports
+    // them — and reports them *weighted*.
+    const observerContext = await browser.newContext()
+    await prepareContext(observerContext)
+    try {
+      const observer = await observerContext.newPage()
+      await observer.goto(`/processes/${processId}`)
+
+      // One ballot was cast (the count is ballots, not weight)...
+      await expect(observer.getByTestId('process-vote-count')).toContainText('1', { timeout: 120_000 })
+
+      // ...but every selected choice tallies the voter's weight of 7. This is
+      // the weighted-census assertion: a non-weighted census would read 1.
+      // Only the trigger part carries `data-value`; the content part is
+      // addressed by its selected state (zag marks the active panel with
+      // `data-selected` and hides the rest).
+      await observer.locator('[data-scope="tabs"][data-part="trigger"][data-value="results"]').click()
+      const results = observer.locator('[data-scope="tabs"][data-part="content"][data-selected]')
+
+      // The innermost div holding the choice label is its tally row (ancestors
+      // match `hasText` too, so `.last()` — document order puts the deepest
+      // match at the end).
+      const tallyRow = (choice: string) => results.locator('div').filter({ hasText: choice }).last()
+
+      await expect(tallyRow('Reject renewal')).toContainText('7 votes')
+      await expect(tallyRow('Approve renewal')).toContainText('0 votes')
+      await expect(tallyRow('Alice Example')).toContainText('7 votes')
+      await expect(tallyRow('Bob Example')).toContainText('7 votes')
+      await expect(tallyRow('New park')).toContainText('7 votes')
+      await expect(tallyRow('New library')).toContainText('0 votes')
+    } finally {
+      await observerContext.close()
+    }
+  })
+})


### PR DESCRIPTION
Fable 5 here, controlled by elboletaire.

## What

Adds `e2e/weighted-question-matrix.e2e.ts`: the manual QA "creating processes matrix" folded into a single UI-driven journey, on top of the existing e2e scaffold.

The original checklist crossed census types × question types × presentations × weighting. Mapped against today's app, most of it collapses:

- **Census types**: the wizard only builds memberbase/CSP censuses now (`CensusTypes` contains only `CSP`) — the spreadsheet and web3 branches of the matrix no longer exist in the UI.
- **Question type + extended info** are per-question settings, and every question publishes as its own on-chain election (multiprocess) — so the whole single/multi × plain/extended matrix fits in **one process**.
- **Weighted vs non-weighted** survives as a census-level option fed by the memberbase weight column.

Since `csp-2fa-voting.e2e.ts` already covers *non-weighted + single choice + plain*, the new spec takes everything else in one weighted process:

1. Signup → organization → CSV memberbase import **with a `weight` column** (voting powers 7/3/1).
2. Create + publish a **weighted** process with three questions: single+extended, multi+plain, multi+extended (per-choice descriptions typed through the extended editor).
3. The member with power 7 authenticates via emailed OTP, sees the extended descriptions and their voting power on the ballot, and casts all three questions in one batch.
4. A fresh anonymous observer confirms **1 ballot** cast but **7 votes** tallied per selected choice (0 on unselected ones) — proving the weight flowed CSV → census → chain → public results.

## Supporting changes

- `helpers/flows.ts`: `ProcessSpec` now takes a `questions[]` array (type / extended info / descriptions per question) plus a `weighted` flag; `castVote` split into reusable `fillBallot`/`submitBallot`.
- `helpers/data.ts`: members and their CSV grow an optional weight column; the importer maps it when present.
- Existing csp-2fa call sites updated to the new spec shape; README coverage table updated.

No workflow changes: the integration job picks the spec up via `testMatch: '**/*.e2e.ts'` and keeps running on PRs against `stage`/`main` and pushes to `develop`.

## How it was verified

`pnpm test:e2e:stack` — 5/5 passing (the new spec runs in ~42s), plus `pnpm lint` and `pnpm test` (813 passed).
