### PR TITLE
test: clear every warning the unit suite emits

### DIFF
--- a/src/components/Auth/vertical/useAuthVertical.test.tsx
+++ b/src/components/Auth/vertical/useAuthVertical.test.tsx
@@ -25,7 +25,13 @@ beforeEach(() => {
 
 afterEach(async () => {
   vi.restoreAllMocks()
-  if (i18n.language !== 'en') await i18n.changeLanguage('en')
+  // Still-mounted hooks are subscribed to i18next, so the reset re-renders them. It runs
+  // before Testing Library's cleanup, hence the act wrapper.
+  if (i18n.language !== 'en') {
+    await act(async () => {
+      await i18n.changeLanguage('en')
+    })
+  }
 })
 
 describe('useAuthVertical', () => {

--- a/src/components/Process/Create/MainContent/QuestionSettings.test.tsx
+++ b/src/components/Process/Create/MainContent/QuestionSettings.test.tsx
@@ -1,5 +1,6 @@
+import userEvent from '@testing-library/user-event'
 import { FormProvider, useForm } from 'react-hook-form'
-import { fireEvent, render, screen } from '~src/test-utils'
+import { render, screen } from '~src/test-utils'
 import { defaultProcessValues, defaultQuestion, Process, SelectorTypes } from '../common'
 import { QuestionSettings } from './QuestionSettings'
 
@@ -35,11 +36,13 @@ describe('QuestionSettings', () => {
     expect(screen.getByText('Multiple choice')).toBeInTheDocument()
   })
 
-  it('toggles extended info for a single question', () => {
+  it('toggles extended info for a single question', async () => {
     render(<QuestionSettingsHarness questions={[{ ...defaultQuestion }, { ...defaultQuestion }]} />)
     const [first, second] = screen.getAllByRole('checkbox', { name: 'Extended info' })
 
-    fireEvent.click(first)
+    // The switch is an Ark UI machine feeding a react-hook-form `Controller`: the
+    // resulting form update lands a tick after the click, so it needs awaiting.
+    await userEvent.click(first)
 
     expect(first).toBeChecked()
     expect(second).not.toBeChecked()

--- a/src/components/Process/Create/draft-saver.test.tsx
+++ b/src/components/Process/Create/draft-saver.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from '@tanstack/react-query'
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { createTestQueryClient } from '~src/test-utils'
 import { setReactProvidersMock } from '~src/test-utils-react-providers-mock'
 import { CensusTypes } from '../Census/CensusType'
@@ -95,8 +95,11 @@ describe('useFormDraftSaver', () => {
     expect(update).not.toHaveBeenCalledWith('draft-1', { published: true })
 
     inFlight.resolve()
-    await saving
-    await publishing
+    // Settling the writes runs saveDraft's tail, which resets the draft-limit state.
+    await act(async () => {
+      await saving
+      await publishing
+    })
 
     expect(update).toHaveBeenCalledTimes(2)
     expect(update).toHaveBeenLastCalledWith('draft-1', { published: true })
@@ -113,7 +116,9 @@ describe('useFormDraftSaver', () => {
     await expect(result.current.saveDraft(true)).resolves.toBe('skipped')
 
     inFlight.resolve()
-    await saving
+    await act(async () => {
+      await saving
+    })
     expect(update).toHaveBeenCalledTimes(1)
   })
 

--- a/src/elements/processes/view.test.tsx
+++ b/src/elements/processes/view.test.tsx
@@ -44,6 +44,9 @@ describe('Process view', () => {
         {
           path: '/processes/:id',
           id: 'process-view',
+          // Mirrors the real route: without a hydrate fallback react-router renders
+          // nothing while the loader runs, and warns about it.
+          HydrateFallback: () => null,
           loader: async () => ({ era: 'saas', election: { id: '123', orgAddress: 'abc' } }),
           element: <Process />,
         },
@@ -79,6 +82,7 @@ describe('Process view', () => {
         {
           path: '/processes/:id',
           id: 'process-view',
+          HydrateFallback: () => null,
           loader: async () => ({ era: 'saas', election: { id: '123', orgAddress: 'abc' } }),
           element: <Process />,
         },
@@ -109,6 +113,7 @@ describe('Process view', () => {
         {
           path: '/processes/:id',
           id: 'process-view',
+          HydrateFallback: () => null,
           loader: async () => ({ era: 'saas', election: { id: '123', orgAddress: 'abc' } }),
           element: <Process />,
         },
@@ -138,6 +143,7 @@ describe('Process view', () => {
         {
           path: '/processes/:id',
           id: 'process-view',
+          HydrateFallback: () => null,
           loader: async () => ({
             era: 'archive',
             legacyElection: { id: legacyId, organizationId: 'df48fb84a39242adec0f72812132d5ec0886c454' },
@@ -166,6 +172,7 @@ describe('Process view', () => {
       [
         {
           path: '/organization/:address',
+          HydrateFallback: () => null,
           loader: async () => ({ address: '0xabc' }),
           element: <div>Organization page</div>,
         },

--- a/src/router/Router.stability.test.tsx
+++ b/src/router/Router.stability.test.tsx
@@ -25,7 +25,9 @@ vi.mock('./routes/dashboard', () => ({
     path: '/dashboard/:id',
     element: <Loaded />,
     // A route whose initial navigation is still in flight when effects first run —
-    // the shape of every real loader route (/admin/process/:id, /processes/:id, ...).
+    // the shape of every real loader route (/admin/process/:id, /processes/:id, ...),
+    // hydrate fallback included.
+    HydrateFallback: () => <div>LOADING</div>,
     loader: async () => {
       await new Promise((resolve) => setTimeout(resolve, 10))
       return 'LOADED'

--- a/src/router/routes/dashboard.test.ts
+++ b/src/router/routes/dashboard.test.ts
@@ -14,6 +14,7 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('../SuspenseLoader', () => ({
   SuspenseLoader: ({ children }: { children: React.ReactNode }) => children ?? Fragment,
+  Loading: () => null,
 }))
 
 describe('shouldRevalidateDashboardProcess', () => {

--- a/src/router/routes/dashboard.tsx
+++ b/src/router/routes/dashboard.tsx
@@ -11,7 +11,7 @@ import ProtectedRoutes from '~src/router/ProtectedRoutes'
 import { Routes } from '.'
 import AccountProtectedRoute from '../AccountProtectedRoute'
 import OrganizationTypeGuard from '../OrganizationTypeGuard'
-import { SuspenseLoader } from '../SuspenseLoader'
+import { Loading, SuspenseLoader } from '../SuspenseLoader'
 
 // elements/pages
 const DashboardCreateOrg = lazy(() => import('~elements/dashboard/organization/create'))
@@ -105,6 +105,7 @@ export const useDashboardRoutes = () => {
                         <DashboardProcessView />
                       </SuspenseLoader>
                     ),
+                    HydrateFallback: Loading,
                     loader: async ({ params }: { params: Params<string> }) => {
                       const rawElection = await client.elections.get(params.id!)
                       // Pre-seed the ElectionProvider query so the view renders without re-fetching

--- a/src/router/routes/home.test.tsx
+++ b/src/router/routes/home.test.tsx
@@ -27,6 +27,7 @@ vi.mock('~components/Home/SharedCensus', () => ({
 vi.mock('~elements/organization/view', () => ({ default: () => <div>OrganizationView</div> }))
 vi.mock('../SuspenseLoader', () => ({
   SuspenseLoader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Loading: () => null,
 }))
 
 const wrapperFor = (processIds: string) => {

--- a/src/router/routes/home.tsx
+++ b/src/router/routes/home.tsx
@@ -5,7 +5,7 @@ import Layout from '~elements/Layout'
 import SimpleLayout from '~elements/SimpleLayout'
 import { useAppEnv, useCustomOrganizationDomains } from '~src/app-env'
 import { useApiClient } from '~src/providers/ApiClientProvider'
-import { SuspenseLoader } from '../SuspenseLoader'
+import { Loading, SuspenseLoader } from '../SuspenseLoader'
 
 const SharedCensus = lazy(() => import('~components/Home/SharedCensus'))
 const OrganizationView = lazy(() => import('~elements/organization/view'))
@@ -31,6 +31,7 @@ export const useHomeRoute = () => {
     return {
       index: true,
       element: <SuspenseLoader>{homeContent}</SuspenseLoader>,
+      HydrateFallback: Loading,
       loader: async () => {
         if (domainForHost) {
           return client.organizations.get(domainForHost)

--- a/src/router/routes/integrators.test.tsx
+++ b/src/router/routes/integrators.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('../SuspenseLoader', () => ({
   SuspenseLoader: ({ children }: { children: React.ReactNode }) => children ?? Fragment,
+  Loading: () => null,
 }))
 
 describe('integrators routes', () => {

--- a/src/router/routes/root.tsx
+++ b/src/router/routes/root.tsx
@@ -14,7 +14,7 @@ import {
 } from '~src/legacy/vochain-archive'
 import { useApiClient } from '~src/providers/ApiClientProvider'
 import { Routes } from '.'
-import { SuspenseLoader } from '../SuspenseLoader'
+import { Loading, SuspenseLoader } from '../SuspenseLoader'
 
 // elements / pages
 const NotFound = lazy(() => import('~elements/NotFound'))
@@ -35,6 +35,9 @@ const RootElements = (client: VocdoniApiClient, vochainGateway: string) => [
         <Process />
       </SuspenseLoader>
     ),
+    // Shown while the loader below runs on a cold load of this URL; without it react-router
+    // renders nothing at all (and says so in the console).
+    HydrateFallback: Loading,
     // 64-hex vochain ids resolve against the read-only archive; Mongo ids against the SaaS API.
     loader: async ({ params }: { params: Params<string> }) => {
       const id = params.id!
@@ -59,6 +62,7 @@ const RootElements = (client: VocdoniApiClient, vochainGateway: string) => [
         <OrganizationView />
       </SuspenseLoader>
     ),
+    HydrateFallback: Loading,
     // Addresses look the same in both eras: the SaaS API is authoritative and
     // the archive serves the addresses it doesn't know (legacy-only orgs).
     loader: async ({ params }: { params: Params<string> }) => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -133,6 +133,14 @@ Object.defineProperty(globalThis, 'localStorage', {
   writable: true,
 })
 
+// jsdom leaves window.scrollTo unimplemented and logs a "Not implemented" error the
+// moment anything calls it — react-router's <ScrollRestoration /> does, on every
+// navigation. Same class of gap as matchMedia/ResizeObserver above, so stub it the same way.
+Object.defineProperty(window, 'scrollTo', {
+  value: () => {},
+  writable: true,
+})
+
 class ResizeObserverMock {
   observe() {}
   unobserve() {}


### PR DESCRIPTION
Opus 5 here, controlled by elboletaire.

## What

`pnpm test` was emitting warnings on every run. This clears all of them, and fixes the one piece of app code behind them.

The reason nobody noticed: **vitest 4's default reporter hides console output for passing tests**. `pnpm test` looked clean while six stderr blocks were being swallowed. They only show under `--reporter=verbose`.

| Warning | Where it fired | Fix |
|---|---|---|
| `An update to Controller … not wrapped in act` | `QuestionSettings.test.tsx` | `fireEvent.click` → `await userEvent.click`. The Ark UI switch feeds react-hook-form's `Controller` a tick later; awaiting the click covers it. |
| `An update to TestComponent …` ×3 | `useAuthVertical.test.tsx` | The file's `afterEach` resets i18next while hooks are still subscribed — and it runs *before* Testing Library's cleanup. Wrapped that reset in `act`. |
| `An update to TestComponent …` ×2 | `draft-saver.test.tsx` | Awaiting the settled writes resumes `saveDraft`, whose tail calls `setDraftLimitReached`. Wrapped the settle in `act` — the update originates in the test, so `act` is the right tool here. |
| ``No `HydrateFallback` element…`` ×2 | `processes/view.test.tsx`, `Router.stability.test.tsx` | See below. |
| `Not implemented: Window's scrollTo()` | `Providers.test.tsx` | jsdom gap; stubbed in `vitest.setup.ts` next to the existing `matchMedia`/`ResizeObserver` stubs. |

No warning was silenced through console mocking or reporter config — each one is fixed at its source.

Every warning was traced with `--printConsoleTrace` rather than guessed at. That's how the draft-saver one resolved to `index.tsx:304`, and how the `scrollTo` one turned out to come from react-router's `<ScrollRestoration />` rather than from `View.tsx`, which was the obvious-looking suspect.

## One change that goes beyond the tests

The `HydrateFallback` warning was firing in **app code**, not only in fixtures: none of the four loader routes had a fallback, so a cold load of `/processes/:id`, `/organization/:address`, `/admin/process/:id` or a custom-domain home rendered *nothing* until the loader resolved. They now point at the same `Loading` their `SuspenseLoader` already uses, so those URLs show a spinner instead of a blank page.

That is a real behaviour change (blank → spinner) inside an otherwise test-only PR, so it is isolated in its own commit (`3beb861`) and easy to drop if you'd rather ship it separately.

It also caught its own bug: three route tests mock `../SuspenseLoader`, and the suite failed on the missing `Loading` export until those mocks were extended — the suite doing its job.

## Verification

- `pnpm test` → 869 passed, 1 skipped, 0 failures
- `npx vitest run --reporter=verbose` → **0 stderr blocks** (was 6)
- `pnpm lint` → clean

No translation keys were touched, so `pnpm translations` was not needed.

## Risk

The router change is verified by tsc and the existing route tests only — the spinner was not watched rendering in a browser. Worth a quick manual look at a cold `/processes/:id` load before merging.
