### PR TITLE
fix(deps): restore ws & decode-uri-component security overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,10 +136,5 @@
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^5.0.0"
   },
-  "packageManager": "pnpm@10.16.1",
-  "pnpm": {
-    "overrides": {
-      "axios": "^1.18.0"
-    }
-  }
+  "packageManager": "pnpm@10.16.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  ws@^8: ^8.21.0
+  decode-uri-component@<0.5.0: ^0.5.0
   axios: ^1.18.0
 
 importers:
@@ -3740,9 +3742,9 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
-  decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
-    engines: {node: '>=0.10'}
+  decode-uri-component@0.5.0:
+    resolution: {integrity: sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==}
+    engines: {node: '>=14.16'}
 
   dedent@1.7.1:
     resolution: {integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==}
@@ -4524,12 +4526,12 @@ packages:
   isows@1.0.6:
     resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
-      ws: '*'
+      ws: ^8.21.0
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: ^8.21.0
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -6570,30 +6572,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -7657,7 +7635,7 @@ snapshots:
       '@ethersproject/transactions': 5.8.0
       '@ethersproject/web': 5.8.0
       bech32: 1.1.4
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11739,7 +11717,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decode-uri-component@0.2.2: {}
+  decode-uri-component@0.5.0: {}
 
   dedent@1.7.1(babel-plugin-macros@3.1.0):
     optionalDependencies:
@@ -11885,7 +11863,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -12607,17 +12585,17 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
-  isows@1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+  isows@1.0.6(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-
-  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
-    dependencies:
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
+  isows@1.0.7(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   jake@10.9.4:
     dependencies:
@@ -13773,7 +13751,7 @@ snapshots:
 
   query-string@7.1.3:
     dependencies:
-      decode-uri-component: 0.2.2
+      decode-uri-component: 0.5.0
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
@@ -14671,9 +14649,9 @@ snapshots:
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.9.3)(zod@4.3.5)
-      isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isows: 1.0.6(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.6.7(typescript@5.9.3)(zod@4.3.5)
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14688,9 +14666,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.22.4)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isows: 1.0.7(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.11.1(typescript@5.9.3)(zod@3.22.4)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14705,9 +14683,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isows: 1.0.7(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.11.1(typescript@5.9.3)(zod@4.3.5)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14989,16 +14967,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
-
-  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
-
-  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,8 @@ overrides:
   # dropped it in 2.24.0), so the jump is safe. Drop this once the
   # wagmi/rainbowkit stack pulls @walletconnect/* >= 2.24.
   'decode-uri-component@<0.5.0': ^0.5.0
+  # @coinbase/cdp-sdk 1.55.0 pins axios 1.16.0 exact, below the 1.18.0 fix for
+  # GHSA-gcfj-64vw-6mp9 (high, inherited-proxy leak via interceptor config
+  # cloning) plus several moderate prototype-pollution/DoS advisories. Drop this
+  # once @coinbase/cdp-sdk pins axios >= 1.18.0.
+  axios: ^1.18.0


### PR DESCRIPTION
Opus 5 here, controlled by elboletaire.

Closes Dependabot alerts #181, #211 (`ws >= 8.0.0 < 8.21.0`) and #252 (`decode-uri-component <= 0.4.2`) by fixing the lockfile. **No alert was dismissed** — the resolved tree no longer contains the vulnerable versions.

## What happened

#1782 (2d4eff9e0) added a `pnpm` > `overrides` block to `package.json` and regenerated `pnpm-lock.yaml`, and the regenerated lockfile came back with only one override in its header:

```yaml
overrides:
  axios: ^1.18.0
```

The two security floors that live in `pnpm-workspace.yaml` — `ws@^8: ^8.21.0` and `decode-uri-component@<0.5.0: ^0.5.0` — were gone, so `ws@8.18.0`, `ws@8.18.3` and `decode-uri-component@0.2.2` came back into the resolved tree and the three alerts reopened.

### The gotcha: pnpm 9 vs pnpm 10 read overrides from *different files*

| | `package.json` → `pnpm.overrides` | `pnpm-workspace.yaml` → `overrides` |
|---|---|---|
| **pnpm 9.x** | ✅ read | ❌ ignored |
| **pnpm 10.x** | ❌ ignored (warns) | ✅ read |

They are exact opposites. The lockfile in #1782 was regenerated by a **pnpm 9** install, which honoured the new `package.json` block and silently discarded everything in `pnpm-workspace.yaml`. Nothing failed loudly — the install succeeded, the lockfile was internally consistent, and the only symptom was three Dependabot alerts coming back.

This repo is pinned to `"packageManager": "pnpm@10.16.1"`. Running pnpm 10 here prints the tell:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
       The following keys were ignored: "pnpm.overrides".
```

So under pnpm 10 that block was pure dead weight — its only effect was to hand a pnpm 9 install a way to clobber the real overrides.

## What changed

1. **Removed the `pnpm` block from `package.json`.** Ignored by the pinned pnpm 10, and a loaded footgun for anyone who installs with pnpm 9.
2. **Moved the `axios: ^1.18.0` floor into `pnpm-workspace.yaml`**, next to the others, with a comment explaining why.
3. **Regenerated `pnpm-lock.yaml`** with pnpm 10.16.1 exactly.

### The axios override is still warranted

`pnpm-workspace.yaml`'s policy comment says only to add an entry when a dependent actually pins a vulnerable range, so I checked rather than carrying it over on faith:

- `@coinbase/cdp-sdk@1.55.0` declares `axios: "1.16.0"` — an **exact** pin, not a range.
- axios 1.16.0 is affected by **GHSA-gcfj-64vw-6mp9 (high** — Node HTTP adapter can use an inherited proxy after interceptor config cloning) plus several moderate prototype-pollution / DoS advisories, all fixed in **1.18.0**.

Without the override the tree resolves to a high-severity vulnerable axios, so it stays. (The `axios: ^1.18.0` visible on `axios-retry`'s peer range in the lockfile is the override rewriting it — upstream it is `0.x || 1.x`, which is not the reason the floor is needed.)

## Verification

Lockfile header lists all three overrides again:

```yaml
overrides:
  ws@^8: ^8.21.0
  decode-uri-component@<0.5.0: ^0.5.0
  axios: ^1.18.0
```

Resolved tree, confirmed two ways — grepping `pnpm-lock.yaml` **and** reading the `version` field out of every installed `package.json` under `node_modules/.pnpm`:

| package | before | after |
|---|---|---|
| `ws` | 7.5.13, **8.18.0**, **8.18.3**, 8.21.0, 8.21.3 | 7.5.13, 8.21.0, 8.21.3 |
| `decode-uri-component` | **0.2.2** | 0.5.0 |
| `axios` | 1.20.0 | 1.20.0 (unchanged) |

No `ws` in `[8.0.0, 8.21.0)` remains. `ws@7.5.13` (via `@walletconnect/jsonrpc-ws-connection`) is untouched and outside the alerts' range — checked against the GitHub advisory DB, it has no open advisories, and the `ws@^8` override is deliberately scoped to major 8.

- `pnpm install` with **pnpm 10.16.1** (verified via `pnpm --version` before installing) ✅
- `pnpm install --frozen-lockfile` — what CI runs ✅
- `pnpm lint` ✅
- `pnpm test` — 869 passed, 1 skipped, 160 files ✅

Lockfile churn is limited to `ws`, `decode-uri-component`, `isows` peer-resolution keys and the `bufferutil`/`utf-8-validate` peer suffixes inside them. No unrelated dependency movement.

## For reviewers

**Whenever you touch overrides in this repo, use pnpm 10.** After any dependency change, the header of `pnpm-lock.yaml` should list all three overrides — if one is missing, the install was run with pnpm 9 and security floors have been silently dropped. `corepack` or `npx pnpm@10.16.1` if your PATH has pnpm 9.

Worth considering as a follow-up (not in this PR): a CI check asserting the lockfile header contains every override from `pnpm-workspace.yaml`, which would have caught this at review time instead of via Dependabot.

Unrelated observation while verifying, deliberately **not** fixed here to keep the diff focused: `onlyBuiltDependencies` is absent from `pnpm-workspace.yaml`, so installs warn about ignored build scripts (`esbuild`, `@swc/core`, `keccak`, …). It was removed back in fec8e5e34, well before #1782 — separate issue, happy to file it.
