### PR TITLE
test(e2e): run the integration suite on an emulated phone too

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,10 @@ name: Integration
 # mongo + vocone + saas-backend + MailHog stack (integration/docker-compose.ci.yml),
 # built from published `:main` images.
 #
+# `pnpm test:e2e` runs every project in playwright.config.ts, so this covers both
+# the desktop (`chromium`) and the emulated-phone (`mobile-chrome`) passes. Adding
+# a project needs no change here.
+#
 # Deliberately separate from .github/workflows/test.yml: this job consumes two
 # moving upstream images and a live chain, so a red run often means "upstream
 # moved" rather than "this repo is broken". That must not gate the normal
@@ -31,8 +35,9 @@ jobs:
     name: End-to-end suite
     runs-on: ubuntu-latest
     # The suite publishes real on-chain processes and casts real votes, and
-    # vocone's first boot downloads its zk circuit artifacts. Budget for that.
-    timeout-minutes: 30
+    # vocone's first boot downloads its zk circuit artifacts. Budget for that —
+    # and note every journey now runs twice, desktop and mobile.
+    timeout-minutes: 45
     permissions:
       contents: read
     steps:
@@ -76,7 +81,7 @@ jobs:
           APP_URL: http://localhost:3000
           VOCDONI_ENVIRONMENT: dev
 
-      - name: Run end-to-end suite
+      - name: Run end-to-end suite (desktop + mobile)
         run: pnpm test:e2e
         env:
           SAAS_URL: http://localhost:8080

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -52,6 +52,15 @@ pnpm test:e2e -- --headed                # watch it happen
 pnpm test:e2e:ui                         # Playwright's UI mode
 ```
 
+Every spec runs twice, once per project in `playwright.config.ts`: `chromium`
+and `mobile-chrome` (the `Pixel 7` preset — 412x839, `isMobile`, `hasTouch`, on
+chromium). Both are part of the same `pnpm test:e2e`; add
+`--project=mobile-chrome` to iterate on one.
+
+Below `md` the create wizard's Settings panel is a drawer that starts closed
+and, open, covers the Publish button — `flows.ts` opens and closes it around
+that block, and no-ops at `md` and up.
+
 Playwright starts the app itself (`pnpm serve:ssr` on `:3000`) via its
 `webServer` config, so a build must exist first. `SAAS_URL` is read by the SSR
 server at boot — the same build works against any backend, with no rebuild.
@@ -116,7 +125,10 @@ a break anywhere along that chain fails here.
 - **Prefer structural selectors over copy.** Form inputs carry `name`
   attributes (react-hook-form), Chakra tabs carry `data-value`, choice radios
   carry their ballot `value`, and a form's primary action is
-  `button[type="submit"]`. Reach for `data-testid` only where none of those
+  `button[type="submit"]`.
+- **Do not read a closed panel's state from a field inside it.** react-select
+  forces `visibility: visible` on its own input, so its comboboxes report as
+  visible even inside a hidden sidebar. Assert on the panel. Reach for `data-testid` only where none of those
   exist — each one in `src/` is commented with why.
 - **Always pass `since:` to `waitForEmail`.** Without it a re-run can settle for
   a stale code still sitting in the inbox.
@@ -142,8 +154,8 @@ a break anywhere along that chain fails here.
 
 ## CI
 
-`.github/workflows/integration.yml` runs this on pushes to `develop` and on
-pull requests targeting `stage` or `main` — the merge into the integration
+`.github/workflows/integration.yml` runs this — both projects — on pushes to
+`develop` and on pull requests targeting `stage` or `main` — the merge into the integration
 branch, and the two promotions that actually reach users. Feature PRs into
 `develop` do not run it (they are covered by `test.yml`); use
 **Run workflow** on the Actions tab to trigger it by hand on any branch.

--- a/e2e/helpers/flows.ts
+++ b/e2e/helpers/flows.ts
@@ -119,6 +119,41 @@ export const importMembers = async (page: Page, members: TestMember[]): Promise<
   await expect(page.getByText(first.email, { exact: false })).toBeVisible({ timeout: 120_000 })
 }
 
+/**
+ * Narrower than Chakra's `md` breakpoint — the same question the components
+ * ask. Read from the viewport, not the project name, so adding or renaming a
+ * device project cannot break it.
+ */
+const isMobileViewport = (page: Page): boolean => (page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) < 768
+
+/**
+ * The wizard's Settings panel, identified by a field only it contains.
+ *
+ * Assert open/closed here, never on a field inside it: react-select forces
+ * `visibility: visible` on its own input, so every combobox in the panel still
+ * reports as visible while it is shut.
+ */
+const wizardSettings = (page: Page): Locator => page.locator('aside').filter({ has: page.locator('#resultVisibility') })
+
+/**
+ * Opens the Settings panel when it is a drawer. No-op at `md` and up, where it
+ * is a docked sidebar that is always open.
+ */
+const openWizardSettings = async (page: Page): Promise<void> => {
+  if (!isMobileViewport(page)) return
+
+  await page.getByTestId('wizard-settings-toggle').click()
+  await expect(wizardSettings(page)).toBeVisible()
+}
+
+/** Closes it again: open, the drawer covers the top bar, Publish included. */
+const closeWizardSettings = async (page: Page): Promise<void> => {
+  if (!isMobileViewport(page)) return
+
+  await page.getByTestId('wizard-settings-close').click()
+  await expect(wizardSettings(page)).toBeHidden()
+}
+
 export type ChoiceSpec = {
   label: string
   /** Filled through the extended-info editor; requires `extendedInfo` on the question. */
@@ -233,6 +268,9 @@ export const createAndPublishTwoFactorProcess = async (page: Page, spec: Process
   // obvious message instead of at the publish step's validation errors.
   await expect(page.locator('input[name="questions.0.title"]')).toHaveValue(spec.questions[0].title)
 
+  // Everything up to the publish click lives in the Settings panel.
+  await openWizardSettings(page)
+
   // Live results, not the "hidden until the end" default: a secret process
   // seals ballots with per-question encryption keys the keykeepers only publish
   // after publication, which is a different feature with its own timing. This
@@ -290,6 +328,8 @@ export const createAndPublishTwoFactorProcess = async (page: Page, spec: Process
   // credentials must be unique and complete across the group) before closing.
   await advance.click()
   await expect(dialog).toBeHidden({ timeout: 60_000 })
+
+  await closeWizardSettings(page)
 
   await page.getByRole('button', { name: /^Publish$/ }).click()
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,6 +46,13 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      // The same specs again, emulated as a phone: most voters are on one, and
+      // the app is a different UI below `md`. Pixel rather than iPhone because
+      // its `defaultBrowserType` is chromium — no second browser download in CI.
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
   ],
   webServer: {
     // Serves dist/, so `pnpm build` must have run first (integration-stack.sh

--- a/src/components/Dashboard/Contents.tsx
+++ b/src/components/Dashboard/Contents.tsx
@@ -83,9 +83,15 @@ export const Sidebar = ({ show, ...props }: SidebarProps) => (
     top={0}
     bottom={0}
     zIndex={10}
-    transition='transform 0.2s ease, opacity 0.2s ease'
+    transition='transform 0.2s ease, opacity 0.2s ease, visibility 0.2s ease'
     transform={show ? 'translateX(0)' : 'translateX(100%)'}
     opacity={show ? 1 : 0}
+    // Closed, `opacity: 0` alone would leave the panel focusable and announced.
+    // `visibility` (transitioned, so it still slides out) fixes that everywhere
+    // except react-select, which forces `visibility: visible` back on its own
+    // input wrapper — hence `inert` too, which nothing inside can override.
+    visibility={show ? 'visible' : 'hidden'}
+    inert={!show}
     pointerEvents={show ? 'auto' : 'none'}
   >
     <Box

--- a/src/components/Process/Create/Sidebar/index.tsx
+++ b/src/components/Process/Create/Sidebar/index.tsx
@@ -19,7 +19,10 @@ export const CreateSidebar = () => {
           <Trans i18nKey='process_create.settings'>Settings</Trans>
         </SidebarTitle>
         {isMobile && (
+          /* data-testid: same reason as the toggle in Create/index.tsx. The open
+             drawer covers the Publish button, so the suite must close it. */
           <IconButton
+            data-testid='wizard-settings-close'
             aria-label={t('drawer.close', { defaultValue: 'Close drawer' })}
             variant='ghost'
             size='sm'

--- a/src/components/Process/Create/index.tsx
+++ b/src/components/Process/Create/index.tsx
@@ -938,7 +938,11 @@ const ProcessCreateView = () => {
                     <Icon as={LuRotateCcw} />
                   </IconButton>
                 )}
+                {/* data-testid: icon-only, so its only other handle is a
+                    translated aria-label — and below `md` the e2e suite must
+                    open this drawer before it can reach any setting. */}
                 <IconButton
+                  data-testid='wizard-settings-toggle'
                   aria-label={t('dashboard.actions.toggle_sidebar', {
                     defaultValue: 'Toggle sidebar',
                   })}

--- a/src/components/Process/Dashboard/ProcessView.test.tsx
+++ b/src/components/Process/Dashboard/ProcessView.test.tsx
@@ -148,8 +148,10 @@ describe('ProcessView navigation', () => {
       expect(navigateSpy).toHaveBeenCalledWith('/admin/process/0xabc/results', { replace: true })
     })
 
-    // Sidebar control panel is rendered alongside the redirect
-    expect(screen.getByRole('button', { name: /end/i })).toBeInTheDocument()
+    // The redirect does not unmount the sidebar control panel. By text, not
+    // role+name: jsdom cannot measure, so the sidebar is closed (hence hidden),
+    // and accessible names skip text inside a hidden subtree.
+    expect(screen.getByText('End vote')).toBeInTheDocument()
   })
 
   it('does not force results again after the user comes back manually to questions', async () => {


### PR DESCRIPTION
Opus 5 here, controlled by elboletaire.

## What

Adds a second Playwright project so every e2e journey runs twice — desktop and an emulated phone — and fixes the one real bug that surfaced when it did.

### The mobile project

`playwright.config.ts` gains a `mobile-chrome` project using Playwright's `Pixel 7` preset: a 412x839 viewport with `isMobile` and `hasTouch`. That combination is what actually flips the app's `base`/`md` breakpoints and Chakra's touch behaviour — a plain narrow viewport would not. Pixel rather than iPhone because its `defaultBrowserType` is chromium, so CI needs no second browser download.

Both projects are part of the same `pnpm test:e2e`, so this is one suite run, not a second command.

### The bug it found

All four voting journeys failed on the first mobile run, at the same line. Below `md` the create wizard's Settings panel is a drawer, and a closed `Sidebar` was hidden with `opacity: 0` + `pointer-events: none` only. That hides it from sight and from the mouse, but leaves it **focusable and in the accessibility tree** — a keyboard user tabs straight into a panel that is not on screen, and on mobile that panel is the full viewport parked just off the right edge. The whole Settings drawer (dates, comboboxes, the voter-authentication button) sat in the tab order while shut.

`visibility: hidden` plus `inert` fixes it. Neither is enough alone, and that took measuring to establish: react-select — so chakra-react-select, so every combobox in these panels — writes `visibility: visible` back onto its own input wrapper, defeating the inherited `hidden`. `inert` is an attribute, so nothing inside can override it. Visibility is transitioned, so the panel still slides out instead of blinking away.

### The test changes

`flows.ts` opens the Settings drawer before the settings block and closes it before publishing (open, it covers the whole viewport including the Publish button). Both helpers no-op at `md` and up, so **the desktop path is byte-for-byte the same journey as before**. They key off viewport width against Chakra's `md` breakpoint (768px) rather than the project name, so renaming or adding a device project does not break them.

Two `data-testid`s in `src/` for the drawer's toggle and close button. Both are icon-only buttons named only by a translated `aria-label`, so there was no structural, copy-free handle — each is commented with why, per `e2e/README.md`'s rule.

One unit-test assertion moved from `getByRole('button', { name: /end/i })` to `getByText`: under jsdom `useBreakpointValue` cannot measure, so that sidebar is closed, and accessible-name computation correctly skips text inside a hidden subtree. The test's intent — "the redirect does not unmount the panel" — is unchanged.

## Why

Most voters reach a process on a phone. A voting journey that only works at 1280px wide is a journey that does not work, and nothing in CI could tell us. The first mobile run found a real a11y defect within minutes, which is roughly the argument for having it.

## CI

`.github/workflows/integration.yml` already ran on pushes to `develop` and on PRs targeting `stage` or `main`; since `pnpm test:e2e` runs every project, the mobile pass is included with no new step. **Nothing was added for PRs into `develop`.** Its `timeout-minutes` goes 30 → 45 now that every journey runs twice.

## How it was verified

Locally, against the real disposable stack (mongo + vocone + saas-backend + MailHog), on the documented one-liner:

```
$ pnpm test:e2e:stack
  ✓ 1-6   [chromium]      … (all four specs)
  ✓ 7-12  [mobile-chrome] … (all four specs)
  12 passed (5.0m)
```

- `pnpm lint` — clean (`tsc`, `tsc -p e2e`, prettier).
- `pnpm test` — 869 passed, 1 skipped, 0 failed.
- No i18n keys touched, so no `pnpm translations` run was needed.

The `visibility`/`inert` behaviour was checked by re-deriving rather than by reading: a standalone chromium repro confirmed the transition timing and that Playwright reports the subtree hidden, and a throwaway render confirmed Chakra emits both `visibility: hidden` and `inert=""` when closed and neither when open. The react-select override was found by dumping the computed-style chain in the live page, not inferred.

## Risk

Verified against `ghcr.io/vocdoni/{saas-backend,vocdoni-node}:main` as of this run. Worth watching on the first CI run: the suite roughly doubles in wall-clock (5 min locally, more on a runner), and 45 minutes is a budget rather than a measurement.
